### PR TITLE
Fix Steam credentials and stats update

### DIFF
--- a/backend/config.go
+++ b/backend/config.go
@@ -115,6 +115,12 @@ func (a *App) initConfig() {
 			appLog("[Config] YouTube Client Secret loaded from .env")
 		}
 	}
+	if a.config.SteamAPIKey == "" {
+		a.config.SteamAPIKey = os.Getenv("STEAM_API_KEY")
+		if a.config.SteamAPIKey != "" {
+			appLog("[Config] Steam API Key loaded from .env")
+		}
+	}
 }
 
 // saveConfig persists the current config to disk

--- a/backend/steam.go
+++ b/backend/steam.go
@@ -14,25 +14,35 @@ import (
 
 // SaveSteamAPIKey saves the user's Steam Web API Key
 func (a *App) SaveSteamAPIKey(key string) error {
+	a.configMu.Lock()
 	a.config.SteamAPIKey = strings.TrimSpace(key)
+	a.configMu.Unlock()
 	return a.saveConfig()
 }
 
 // GetSteamAPIKey returns the current API key
 func (a *App) GetSteamAPIKey() string {
+	a.configMu.RLock()
+	defer a.configMu.RUnlock()
 	return a.config.SteamAPIKey
 }
 
 // GetSteamID returns the current Steam ID
 func (a *App) GetSteamID() string {
+	a.configMu.RLock()
+	defer a.configMu.RUnlock()
 	return a.config.SteamID
 }
 
 // DisconnectSteam clears Steam credentials
 func (a *App) DisconnectSteam() error {
+	a.configMu.Lock()
 	a.config.SteamAPIKey = ""
 	a.config.SteamID = ""
-	return a.saveConfig()
+	a.configMu.Unlock()
+	err := a.saveConfig()
+	runtime.EventsEmit(a.ctx, "steam:auth-disconnected")
+	return err
 }
 
 // LoginSteam starts the OpenID flow and blocks until completion or error
@@ -128,8 +138,11 @@ func (a *App) LoginSteam() (string, error) {
 	select {
 	case steamID := <-resultCh:
 		server.Shutdown(context.Background())
+		a.configMu.Lock()
 		a.config.SteamID = steamID
+		a.configMu.Unlock()
 		a.saveConfig()
+		runtime.EventsEmit(a.ctx, "steam:auth-complete")
 		return steamID, nil
 	case err := <-errCh:
 		server.Shutdown(context.Background())

--- a/frontend/src/pages/SteamStats.tsx
+++ b/frontend/src/pages/SteamStats.tsx
@@ -130,11 +130,21 @@ export default function SteamStats() {
       setError(errMsg);
     });
 
+    const unsubAuth = EventsOn("steam:auth-complete", () => {
+      loadData(true);
+    });
+
+    const unsubDisconnect = EventsOn("steam:auth-disconnected", () => {
+      loadData(false);
+    });
+
     return () => {
       unsubProgress();
       unsubGamesUpdated();
       unsubDone();
       unsubError();
+      unsubAuth();
+      unsubDisconnect();
     };
   }, [loadData]);
 


### PR DESCRIPTION
This adds .env support for Steam API Key, fixes missing concurrency locks for Steam settings, and implements live UI updates on the SteamStats page when logging in or out.

Fixes #12