### PR TITLE
Fix slow thumbnail loading and separate preview queue (fixes #20)

### DIFF
--- a/backend/app.go
+++ b/backend/app.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -40,6 +41,19 @@ func NewApp() *App {
 		uploads: make(map[string]context.CancelFunc),
 	}
 	a.initCache()
+	return a
+}
+
+// NewTestApp creates an App configured for unit testing with a custom cache directory.
+func NewTestApp(cacheDir string) *App {
+	a := &App{
+		cacheDir: cacheDir,
+		thumbSem: make(chan struct{}, 2),
+		uploads:  make(map[string]context.CancelFunc),
+	}
+	_ = os.MkdirAll(filepath.Join(cacheDir, "thumbs"), 0755)
+	_ = os.MkdirAll(filepath.Join(cacheDir, "previews"), 0755)
+	_ = os.MkdirAll(filepath.Join(cacheDir, "durations"), 0755)
 	return a
 }
 

--- a/backend/media.go
+++ b/backend/media.go
@@ -36,7 +36,11 @@ func (a *App) initCache() {
 	fmt.Printf("Thumbnail worker limit: %d (of %d CPUs)\n", workers, runtime.NumCPU())
 }
 
-// cacheKey builds a unique filename from path + mod time
+// CacheKey builds a unique filename from path + mod time
+func CacheKey(path string, modTime time.Time) string {
+	return cacheKey(path, modTime)
+}
+
 func cacheKey(path string, modTime time.Time) string {
 	raw := fmt.Sprintf("%s|%d", path, modTime.UnixNano())
 	sum := md5.Sum([]byte(raw))

--- a/backend/media.go
+++ b/backend/media.go
@@ -52,6 +52,7 @@ func (a *App) GetCacheDir() string {
 // GetThumbnail returns a local cache URL for a video file thumbnail.
 // It respects the global thumbSem semaphore to cap concurrent ffmpeg processes.
 func (a *App) GetThumbnail(path string) (string, error) {
+	start := time.Now()
 	info, err := os.Stat(path)
 	if err != nil {
 		appLog("[Media] GetThumbnail failed (file not found): %s", path)
@@ -63,8 +64,11 @@ func (a *App) GetThumbnail(path string) (string, error) {
 
 	// Cache hit — no ffmpeg needed, skip semaphore.
 	if _, err := os.Stat(cachePath); err == nil {
+		appLog("[Media] GetThumbnail CACHE HIT for %s in %v", filepath.Base(path), time.Since(start))
 		return urlPath, nil
 	}
+
+	appLog("[Media] GetThumbnail CACHE MISS for %s (queued for generation)", filepath.Base(path))
 
 	// Acquire a worker slot before spawning ffmpeg.
 	a.thumbSem <- struct{}{}
@@ -89,6 +93,7 @@ func (a *App) GetThumbnail(path string) (string, error) {
 		appLog("[Media] GetThumbnail failed for %s: ffmpeg error: %v", filepath.Base(path), err)
 		return "", fmt.Errorf("failed to generate thumbnail: %w", err)
 	}
+	appLog("[Media] GetThumbnail GENERATED for %s in %v", filepath.Base(path), time.Since(start))
 	return urlPath, nil
 }
 
@@ -115,6 +120,7 @@ func (a *App) RegenerateThumbnail(path string) (string, error) {
 // GetVideoPreview generates a 5x5 sprite sheet preview for a video file.
 // It respects the global thumbSem semaphore to cap concurrent ffmpeg processes.
 func (a *App) GetVideoPreview(path string) (string, error) {
+	start := time.Now()
 	info, err := os.Stat(path)
 	if err != nil {
 		appLog("[Media] GetVideoPreview failed (file not found): %s", path)
@@ -126,8 +132,11 @@ func (a *App) GetVideoPreview(path string) (string, error) {
 
 	// Cache hit — no ffmpeg needed, skip semaphore.
 	if _, err := os.Stat(cachePath); err == nil {
+		appLog("[Media] GetVideoPreview CACHE HIT for %s in %v", filepath.Base(path), time.Since(start))
 		return urlPath, nil
 	}
+
+	appLog("[Media] GetVideoPreview CACHE MISS for %s (queued for generation)", filepath.Base(path))
 
 	// Acquire a worker slot before spawning ffmpeg.
 	a.thumbSem <- struct{}{}
@@ -151,12 +160,14 @@ func (a *App) GetVideoPreview(path string) (string, error) {
 		appLog("[Media] GetVideoPreview failed for %s: ffmpeg error: %v", filepath.Base(path), err)
 		return "", fmt.Errorf("failed to generate preview: %w", err)
 	}
+	appLog("[Media] GetVideoPreview GENERATED for %s in %v", filepath.Base(path), time.Since(start))
 	return urlPath, nil
 }
 
 // GetVideoDuration returns the duration of the video in seconds using ffprobe.
 // Results are cached to disk so repeated calls (e.g. after rescan) are free.
 func (a *App) GetVideoDuration(path string) (float64, error) {
+	start := time.Now()
 	info, err := os.Stat(path)
 	if err != nil {
 		return 0, fmt.Errorf("file not found: %w", err)
@@ -167,9 +178,12 @@ func (a *App) GetVideoDuration(path string) (float64, error) {
 	// Cache hit — skip ffprobe entirely.
 	if data, readErr := os.ReadFile(cachePath); readErr == nil {
 		if dur, parseErr := strconv.ParseFloat(strings.TrimSpace(string(data)), 64); parseErr == nil {
+			appLog("[Media] GetVideoDuration CACHE HIT for %s in %v (%.2fs)", filepath.Base(path), time.Since(start), dur)
 			return dur, nil
 		}
 	}
+
+	appLog("[Media] GetVideoDuration CACHE MISS for %s (running ffprobe)", filepath.Base(path))
 
 	// Acquire a worker slot before spawning ffprobe.
 	a.thumbSem <- struct{}{}
@@ -195,5 +209,6 @@ func (a *App) GetVideoDuration(path string) (float64, error) {
 	}
 	// Persist to disk for future calls.
 	_ = os.WriteFile(cachePath, []byte(durStr), 0644)
+	appLog("[Media] GetVideoDuration GENERATED for %s in %v (%.2fs)", filepath.Base(path), time.Since(start), duration)
 	return duration, nil
 }

--- a/backend/media_test.go
+++ b/backend/media_test.go
@@ -1,0 +1,147 @@
+package backend
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func setupTestApp(t *testing.T) (*App, string) {
+	tempDir, err := os.MkdirTemp("", "amon-hen-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+
+	app := &App{
+		cacheDir: tempDir,
+		thumbSem: make(chan struct{}, 2),
+	}
+
+	os.MkdirAll(filepath.Join(tempDir, "thumbs"), 0755)
+	os.MkdirAll(filepath.Join(tempDir, "previews"), 0755)
+	os.MkdirAll(filepath.Join(tempDir, "durations"), 0755)
+
+	return app, tempDir
+}
+
+func TestCacheKey(t *testing.T) {
+	path := "C:/Videos/gameplay.mp4"
+	t1 := time.Unix(1000, 0)
+	t2 := time.Unix(2000, 0)
+
+	key1 := cacheKey(path, t1)
+	key1Repeat := cacheKey(path, t1)
+	key2 := cacheKey(path, t2)
+
+	if key1 != key1Repeat {
+		t.Errorf("Expected identical cache keys for same input, got %s and %s", key1, key1Repeat)
+	}
+
+	if key1 == key2 {
+		t.Errorf("Expected different cache keys for different mod times, got %s for both", key1)
+	}
+}
+
+func TestGetThumbnail_FileNotFound(t *testing.T) {
+	app, tempDir := setupTestApp(t)
+	defer os.RemoveAll(tempDir)
+
+	_, err := app.GetThumbnail(filepath.Join(tempDir, "non_existent.mp4"))
+	if err == nil {
+		t.Errorf("Expected error for non-existent file, got nil")
+	}
+}
+
+func TestGetThumbnail_CacheHit(t *testing.T) {
+	app, tempDir := setupTestApp(t)
+	defer os.RemoveAll(tempDir)
+
+	// Create a dummy video file
+	videoPath := filepath.Join(tempDir, "video.mp4")
+	if err := os.WriteFile(videoPath, []byte("fake video content"), 0644); err != nil {
+		t.Fatalf("Failed to create dummy video: %v", err)
+	}
+
+	info, err := os.Stat(videoPath)
+	if err != nil {
+		t.Fatalf("Failed to stat dummy video: %v", err)
+	}
+
+	key := cacheKey(videoPath, info.ModTime())
+	cachedThumbPath := filepath.Join(tempDir, "thumbs", key+".jpg")
+	if err := os.WriteFile(cachedThumbPath, []byte("fake thumbnail image"), 0644); err != nil {
+		t.Fatalf("Failed to create cached thumbnail: %v", err)
+	}
+
+	url, err := app.GetThumbnail(videoPath)
+	if err != nil {
+		t.Fatalf("GetThumbnail returned error on cache hit: %v", err)
+	}
+
+	expectedURL := "/cache/thumbs/" + key + ".jpg"
+	if url != expectedURL {
+		t.Errorf("Expected URL %s, got %s", expectedURL, url)
+	}
+}
+
+func TestGetVideoPreview_CacheHit(t *testing.T) {
+	app, tempDir := setupTestApp(t)
+	defer os.RemoveAll(tempDir)
+
+	videoPath := filepath.Join(tempDir, "video.mp4")
+	if err := os.WriteFile(videoPath, []byte("fake video content"), 0644); err != nil {
+		t.Fatalf("Failed to create dummy video: %v", err)
+	}
+
+	info, err := os.Stat(videoPath)
+	if err != nil {
+		t.Fatalf("Failed to stat dummy video: %v", err)
+	}
+
+	key := cacheKey(videoPath, info.ModTime())
+	cachedPreviewPath := filepath.Join(tempDir, "previews", key+".jpg")
+	if err := os.WriteFile(cachedPreviewPath, []byte("fake preview sheet"), 0644); err != nil {
+		t.Fatalf("Failed to create cached preview: %v", err)
+	}
+
+	url, err := app.GetVideoPreview(videoPath)
+	if err != nil {
+		t.Fatalf("GetVideoPreview returned error on cache hit: %v", err)
+	}
+
+	expectedURL := "/cache/previews/" + key + ".jpg"
+	if url != expectedURL {
+		t.Errorf("Expected URL %s, got %s", expectedURL, url)
+	}
+}
+
+func TestGetVideoDuration_CacheHit(t *testing.T) {
+	app, tempDir := setupTestApp(t)
+	defer os.RemoveAll(tempDir)
+
+	videoPath := filepath.Join(tempDir, "video.mp4")
+	if err := os.WriteFile(videoPath, []byte("fake video content"), 0644); err != nil {
+		t.Fatalf("Failed to create dummy video: %v", err)
+	}
+
+	info, err := os.Stat(videoPath)
+	if err != nil {
+		t.Fatalf("Failed to stat dummy video: %v", err)
+	}
+
+	key := cacheKey(videoPath, info.ModTime())
+	cachedDurationPath := filepath.Join(tempDir, "durations", key+".txt")
+	if err := os.WriteFile(cachedDurationPath, []byte("42.50\n"), 0644); err != nil {
+		t.Fatalf("Failed to create cached duration: %v", err)
+	}
+
+	dur, err := app.GetVideoDuration(videoPath)
+	if err != nil {
+		t.Fatalf("GetVideoDuration returned error on cache hit: %v", err)
+	}
+
+	if dur != 42.50 {
+		t.Errorf("Expected duration 42.50, got %f", dur)
+	}
+}

--- a/frontend/src/components/video/InlinePlayer.tsx
+++ b/frontend/src/components/video/InlinePlayer.tsx
@@ -5,6 +5,7 @@ import { UploadToYouTube, SaveVideoMetadata, DeleteFiles, GetChannelPlaylists, G
 import { QueueItem } from "../youtube/UploadQueue";
 import { useRecentTags } from "../../hooks/useRecentTags";
 import { useRecentFieldValues } from "../../hooks/useRecentFieldValues";
+import { setCachedThumb, clearCachedPreview } from "../../hooks/useThumbnailQueue";
 import TagInput from "../ui/TagInput";
 import TagPlaylistModal from "../ui/TagPlaylistModal";
 import FieldInput from "../ui/FieldInput";
@@ -471,7 +472,11 @@ export default function InlinePlayer({ video, streamPort, selectedPaths = [], on
  setRegenLoading(true);
  try {
  const fresh = await RegenerateThumbnail(video.path);
- if (fresh) setRegenThumb(fresh);
+ if (fresh) {
+ setCachedThumb(video.path, fresh);
+ clearCachedPreview(video.path);
+ setRegenThumb(fresh);
+ }
  } catch (e) {
  console.error("Failed to regenerate thumbnail", e);
  } finally {

--- a/frontend/src/components/video/VideoPill.tsx
+++ b/frontend/src/components/video/VideoPill.tsx
@@ -7,123 +7,150 @@ import {
 } from "../../utils/videoUtils";
 import { getTagColor } from "../../utils/tagColors";
 import { useInView } from "../../hooks/useInView";
-import { enqueueThumb } from "../../hooks/useThumbnailQueue";
 import {
- GetThumbnail,
- GetVideoPreview,
- GetVideoDuration,
+	enqueueThumb,
+	enqueueDuration,
+	enqueuePreview,
+	getCachedThumb,
+	setCachedThumb,
+	getCachedDuration,
+	setCachedDuration,
+	getCachedPreview,
+	setCachedPreview,
+} from "../../hooks/useThumbnailQueue";
+import {
+	GetThumbnail,
+	GetVideoPreview,
+	GetVideoDuration,
 } from "../../../wailsjs/go/backend/App";
 
 interface VideoPillProps {
- video: YTVideo | VideoFile;
- selected?: boolean;
- multiSelected?: boolean;
- onClick?: (e: React.MouseEvent) => void;
- onUpload?: () => void;
- onUpdate?: () => void;
- viewMode?: "grid" | "list";
- compact?: boolean;
- uploadProgress?: number; // 0-100 while uploading, undefined otherwise
- uploadSpeed?: number; // bytes per second while uploading
- readOnlyThumbnail?: boolean;
- gameProfiles?: Record<string, GameProfile>;
- onThumbLoaded?: (url: string) => void;
- onSelectToggle?: (e: React.MouseEvent) => void;
+	video: YTVideo | VideoFile;
+	selected?: boolean;
+	multiSelected?: boolean;
+	onClick?: (e: React.MouseEvent) => void;
+	onUpload?: () => void;
+	onUpdate?: () => void;
+	viewMode?: "grid" | "list";
+	compact?: boolean;
+	uploadProgress?: number; // 0-100 while uploading, undefined otherwise
+	uploadSpeed?: number; // bytes per second while uploading
+	readOnlyThumbnail?: boolean;
+	gameProfiles?: Record<string, GameProfile>;
+	onThumbLoaded?: (url: string) => void;
+	onSelectToggle?: (e: React.MouseEvent) => void;
 }
 
 export default function VideoPill({
- video,
- selected,
- multiSelected,
- onClick,
- onUpload,
- onUpdate,
- viewMode = "grid",
- compact = false,
- uploadProgress,
- uploadSpeed,
- readOnlyThumbnail = false,
- gameProfiles = {},
- onThumbLoaded,
- onSelectToggle,
+	video,
+	selected,
+	multiSelected,
+	onClick,
+	onUpload,
+	onUpdate,
+	viewMode = "grid",
+	compact = false,
+	uploadProgress,
+	uploadSpeed,
+	readOnlyThumbnail = false,
+	gameProfiles = {},
+	onThumbLoaded,
+	onSelectToggle,
 }: VideoPillProps) {
- const ref = useRef<HTMLDivElement>(null);
- const inView = useInView(ref);
+	const ref = useRef<HTMLDivElement>(null);
+	const inView = useInView(ref);
 
- // States for local files
- const [thumb, setThumb] = useState("");
- const [sprite, setSprite] = useState("");
- const [bgPos, setBgPos] = useState("0% 0%");
- const [hovered, setHovered] = useState(false);
- const [thumbLoaded, setThumbLoaded] = useState(false);
- const [imgLoaded, setImgLoaded] = useState(false);
- const [localDuration, setLocalDuration] = useState<number | null>(null);
+	// Helper: Is it a YouTube video or a Local file?
+	const isYT = "id" in video && !("path" in video);
+	const isLocal = "path" in video;
+	const localPath = isLocal ? (video as VideoFile).path : "";
 
- // Helper: Is it a YouTube video or a Local file?
- const isYT = "id" in video && !("path" in video);
- const isLocal = "path" in video;
+	// States for local files initialized immediately from memory cache if present
+	const [thumb, setThumb] = useState<string>(() => (isLocal ? getCachedThumb(localPath) || "" : ""));
+	const [sprite, setSprite] = useState<string>(() => (isLocal ? getCachedPreview(localPath) || "" : ""));
+	const [bgPos, setBgPos] = useState("0% 0%");
+	const [hovered, setHovered] = useState(false);
+	const [thumbLoaded, setThumbLoaded] = useState<boolean>(() => (isLocal ? !!getCachedThumb(localPath) : true));
+	const [imgLoaded, setImgLoaded] = useState<boolean>(() => (isLocal ? !!getCachedThumb(localPath) : false));
+	const [localDuration, setLocalDuration] = useState<number | null>(() =>
+		isLocal ? getCachedDuration(localPath) ?? null : null
+	);
 
- // Data normalization
- const activeProfile = isLocal ? gameProfiles[(video as VideoFile).game || ""] : undefined;
- const title = isYT
- ? video.title
- : (activeProfile?.type === "multiplayer")
- ? generateYouTubeTitle(video.name, video.game, video.episode, activeProfile, video.event, video.gameMode, (video as VideoFile).customVars, (video as VideoFile).modTime)
- : video.youtubeTitle || generateYouTubeTitle(video.name, video.game, video.episode, activeProfile, video.event, video.gameMode, (video as VideoFile).customVars, (video as VideoFile).modTime);
- const subtitle = isLocal ? video.name : "";
- const thumbnail = isYT ? video.thumbnailUrl : thumb;
- const publishedAt = isYT
- ? new Date(video.publishedAt).toLocaleDateString()
- : "";
+	// Data normalization
+	const activeProfile = isLocal ? gameProfiles[(video as VideoFile).game || ""] : undefined;
+	const title = isYT
+		? video.title
+		: (activeProfile?.type === "multiplayer")
+		? generateYouTubeTitle(video.name, video.game, video.episode, activeProfile, video.event, video.gameMode, (video as VideoFile).customVars, (video as VideoFile).modTime)
+		: video.youtubeTitle || generateYouTubeTitle(video.name, video.game, video.episode, activeProfile, video.event, video.gameMode, (video as VideoFile).customVars, (video as VideoFile).modTime);
+	const subtitle = isLocal ? video.name : "";
+	const thumbnail = isYT ? video.thumbnailUrl : thumb;
+	const publishedAt = isYT
+		? new Date(video.publishedAt).toLocaleDateString()
+		: "";
 
- // Duration normalization
- const parseYTDuration = (isoDuration: string) => {
- const regex = /PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?/;
- const matches = isoDuration.match(regex);
- if (!matches) return "0:00";
- const h = parseInt(matches[1] || "0");
- const m = parseInt(matches[2] || "0");
- const s = parseInt(matches[3] || "0");
- if (h > 0)
- return `${h}:${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`;
- return `${m}:${s.toString().padStart(2, "0")}`;
- };
+	// Duration normalization
+	const parseYTDuration = (isoDuration: string) => {
+		const regex = /PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?/;
+		const matches = isoDuration.match(regex);
+		if (!matches) return "0:00";
+		const h = parseInt(matches[1] || "0");
+		const m = parseInt(matches[2] || "0");
+		const s = parseInt(matches[3] || "0");
+		if (h > 0)
+			return `${h}:${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`;
+		return `${m}:${s.toString().padStart(2, "0")}`;
+	};
 
- const displayDuration = isYT
- ? parseYTDuration(video.duration)
- : localDuration !== null
- ? formatDuration(localDuration)
- : "";
+	const displayDuration = isYT
+		? parseYTDuration(video.duration)
+		: localDuration !== null
+		? formatDuration(localDuration)
+		: "";
 
- const formatNumber = (num: number) => {
- if (num >= 1000000) return (num / 1000000).toFixed(1) + "M";
- if (num >= 1000) return (num / 1000).toFixed(1) + "K";
- return num.toString();
- };
+	const formatNumber = (num: number) => {
+		if (num >= 1000000) return (num / 1000000).toFixed(1) + "M";
+		if (num >= 1000) return (num / 1000).toFixed(1) + "K";
+		return num.toString();
+	};
 
- useEffect(() => {
- if (isLocal && inView) {
- if (!thumbLoaded) {
- enqueueThumb(() => GetThumbnail(video.path)).then((d) => {
- if (d) {
- setThumb(d);
- if (onThumbLoaded) onThumbLoaded(d);
- }
- setThumbLoaded(true);
- });
- }
- if (!sprite) {
- enqueueThumb(() => GetVideoPreview(video.path)).then((d) => {
- if (d) setSprite(d);
- });
- }
- if (localDuration === null) {
- enqueueThumb(() => GetVideoDuration(video.path)).then((s) => {
- if (s > 0) setLocalDuration(s);
- });
- }
- }
- }, [inView, isLocal, (video as VideoFile).path, thumbLoaded, sprite, localDuration]);
+	// Primary thumbnail & duration loading when entering viewport
+	useEffect(() => {
+		if (isLocal && inView && localPath) {
+			if (!thumb && !thumbLoaded) {
+				enqueueThumb(() => GetThumbnail(localPath)).then((d) => {
+					if (d) {
+						setCachedThumb(localPath, d);
+						setThumb(d);
+						if (onThumbLoaded) onThumbLoaded(d);
+					}
+					setThumbLoaded(true);
+				}).catch(() => {
+					setThumbLoaded(true);
+				});
+			}
+			if (localDuration === null) {
+				enqueueDuration(() => GetVideoDuration(localPath)).then((s) => {
+					if (s > 0) {
+						setCachedDuration(localPath, s);
+						setLocalDuration(s);
+					}
+				}).catch(() => {});
+			}
+		}
+	}, [inView, isLocal, localPath, thumb, thumbLoaded, localDuration, onThumbLoaded]);
+
+	// Secondary preview sprite loading — ONLY triggered when user hovers over card
+	useEffect(() => {
+		if (isLocal && hovered && !sprite && localPath) {
+			enqueuePreview(() => GetVideoPreview(localPath)).then((d) => {
+				if (d) {
+					setCachedPreview(localPath, d);
+					setSprite(d);
+				}
+			}).catch(() => {});
+		}
+	}, [isLocal, hovered, sprite, localPath]);
 
  useEffect(() => {
  if (selected && ref.current && viewMode === "list") {

--- a/frontend/src/hooks/useThumbnailQueue.ts
+++ b/frontend/src/hooks/useThumbnailQueue.ts
@@ -1,51 +1,83 @@
 /**
  * useThumbnailQueue
  *
- * A module-level async semaphore that limits the number of concurrent
- * thumbnail/preview/duration requests sent to the Go backend.
- *
- * Why: When a folder with many clips is opened, useInView fires for all
- * visible cards at once. Without throttling, N×3 backend calls hit ffmpeg
- * simultaneously and saturate the CPU. This queue caps it at CONCURRENCY
- * parallel requests regardless of how many cards become visible at once.
- *
- * The Go backend has its own semaphore too (runtime.NumCPU()/2), so this
- * is a secondary safety net that also improves perceived load order
- * (thumbnails appear top-to-bottom rather than all at once).
+ * Module-level async semaphore and in-memory cache for media assets
+ * (thumbnails, previews, durations).
  */
 
-const CONCURRENCY = 3;
+const thumbCache = new Map<string, string>();
+const durationCache = new Map<string, number>();
+const previewCache = new Map<string, string>();
 
-let active = 0;
-const queue: Array<() => void> = [];
-
-function release() {
- active--;
- if (queue.length > 0) {
- const next = queue.shift()!;
- active++;
- next();
- }
+export function getCachedThumb(path: string): string | undefined {
+  return thumbCache.get(path);
 }
 
-/**
- * Enqueue an async task so that at most CONCURRENCY tasks run at the same time.
- * Returns a Promise that resolves/rejects with the result of `fn`.
- */
-export function enqueueThumb<T>(fn: () => Promise<T>): Promise<T> {
- return new Promise<T>((resolve, reject) => {
- const run = () => {
- fn()
- .then(resolve)
- .catch(reject)
- .finally(release);
- };
-
- if (active < CONCURRENCY) {
- active++;
- run();
- } else {
- queue.push(run);
- }
- });
+export function setCachedThumb(path: string, url: string): void {
+  thumbCache.set(path, url);
 }
+
+export function clearCachedThumb(path: string): void {
+  thumbCache.delete(path);
+}
+
+export function getCachedDuration(path: string): number | undefined {
+  return durationCache.get(path);
+}
+
+export function setCachedDuration(path: string, duration: number): void {
+  durationCache.set(path, duration);
+}
+
+export function getCachedPreview(path: string): string | undefined {
+  return previewCache.get(path);
+}
+
+export function setCachedPreview(path: string, url: string): void {
+  previewCache.set(path, url);
+}
+
+export function clearCachedPreview(path: string): void {
+  previewCache.delete(path);
+}
+
+function createQueue(concurrency: number) {
+  let active = 0;
+  const queue: Array<() => void> = [];
+
+  function release() {
+    active--;
+    if (queue.length > 0) {
+      const next = queue.shift()!;
+      active++;
+      next();
+    }
+  }
+
+  return function enqueue<T>(fn: () => Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const run = () => {
+        fn()
+          .then(resolve)
+          .catch(reject)
+          .finally(release);
+      };
+
+      if (active < concurrency) {
+        active++;
+        run();
+      } else {
+        queue.push(run);
+      }
+    });
+  };
+}
+
+// High concurrency for fast thumbnail queries (cache hits resolve instantly)
+export const enqueueThumb = createQueue(8);
+
+// Dedicated queue for duration probes
+export const enqueueDuration = createQueue(4);
+
+// Dedicated queue for preview sprite generation (heavy ffmpeg on hover)
+export const enqueuePreview = createQueue(2);

--- a/tests/backend/media_test.go
+++ b/tests/backend/media_test.go
@@ -1,27 +1,21 @@
-package backend
+package backend_test
 
 import (
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"amon-hen/backend"
 )
 
-func setupTestApp(t *testing.T) (*App, string) {
+func setupTestApp(t *testing.T) (*backend.App, string) {
 	tempDir, err := os.MkdirTemp("", "amon-hen-test-*")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
 
-	app := &App{
-		cacheDir: tempDir,
-		thumbSem: make(chan struct{}, 2),
-	}
-
-	os.MkdirAll(filepath.Join(tempDir, "thumbs"), 0755)
-	os.MkdirAll(filepath.Join(tempDir, "previews"), 0755)
-	os.MkdirAll(filepath.Join(tempDir, "durations"), 0755)
-
+	app := backend.NewTestApp(tempDir)
 	return app, tempDir
 }
 
@@ -30,9 +24,9 @@ func TestCacheKey(t *testing.T) {
 	t1 := time.Unix(1000, 0)
 	t2 := time.Unix(2000, 0)
 
-	key1 := cacheKey(path, t1)
-	key1Repeat := cacheKey(path, t1)
-	key2 := cacheKey(path, t2)
+	key1 := backend.CacheKey(path, t1)
+	key1Repeat := backend.CacheKey(path, t1)
+	key2 := backend.CacheKey(path, t2)
 
 	if key1 != key1Repeat {
 		t.Errorf("Expected identical cache keys for same input, got %s and %s", key1, key1Repeat)
@@ -68,7 +62,7 @@ func TestGetThumbnail_CacheHit(t *testing.T) {
 		t.Fatalf("Failed to stat dummy video: %v", err)
 	}
 
-	key := cacheKey(videoPath, info.ModTime())
+	key := backend.CacheKey(videoPath, info.ModTime())
 	cachedThumbPath := filepath.Join(tempDir, "thumbs", key+".jpg")
 	if err := os.WriteFile(cachedThumbPath, []byte("fake thumbnail image"), 0644); err != nil {
 		t.Fatalf("Failed to create cached thumbnail: %v", err)
@@ -99,7 +93,7 @@ func TestGetVideoPreview_CacheHit(t *testing.T) {
 		t.Fatalf("Failed to stat dummy video: %v", err)
 	}
 
-	key := cacheKey(videoPath, info.ModTime())
+	key := backend.CacheKey(videoPath, info.ModTime())
 	cachedPreviewPath := filepath.Join(tempDir, "previews", key+".jpg")
 	if err := os.WriteFile(cachedPreviewPath, []byte("fake preview sheet"), 0644); err != nil {
 		t.Fatalf("Failed to create cached preview: %v", err)
@@ -130,7 +124,7 @@ func TestGetVideoDuration_CacheHit(t *testing.T) {
 		t.Fatalf("Failed to stat dummy video: %v", err)
 	}
 
-	key := cacheKey(videoPath, info.ModTime())
+	key := backend.CacheKey(videoPath, info.ModTime())
 	cachedDurationPath := filepath.Join(tempDir, "durations", key+".txt")
 	if err := os.WriteFile(cachedDurationPath, []byte("42.50\n"), 0644); err != nil {
 		t.Fatalf("Failed to create cached duration: %v", err)

--- a/tests/frontend/.gitkeep
+++ b/tests/frontend/.gitkeep
@@ -1,0 +1,1 @@
+# Frontend tests directory


### PR DESCRIPTION
﻿Closes #20

### Summary of Changes
- Added unit tests for backend media cache and thumbnail retrieval functions (`backend/media_test.go`).
- Added execution duration tracking and explicit cache hit/miss logs in `backend/media.go`.
- Introduced in-memory Map caching in frontend to render cached thumbnails immediately on mount without IPC overhead.
- Separated concurrency queues for thumbnails, video durations, and preview sprite generation in `frontend/src/hooks/useThumbnailQueue.ts`.
- Deferred 5x5 preview sprite sheet generation until user hover in `frontend/src/components/video/VideoPill.tsx` to prevent ffmpeg from blocking the main thumbnail queue.
- Updated `InlinePlayer.tsx` to sync in-memory cache upon thumbnail regeneration.

### Verification
- `go test -v ./backend` (all unit tests passed).
- `npm run build` in `frontend` (TypeScript compilation and Vite build passed).
