### PR TITLE
Refactor YouTube sync handlers and centralize test mocks (refs #25)

### DIFF
--- a/frontend/src/pages/ChannelPage.tsx
+++ b/frontend/src/pages/ChannelPage.tsx
@@ -171,27 +171,27 @@ export default function ChannelPage() {
  return () => document.removeEventListener("mousedown", handler);
  }, []);
 
- const handleSyncLight = async () => {
- if (isSyncing) return;
- setShowSyncMenu(false); setIsSyncing(true);
- setSyncStatus("Quick sync — last 20 videos...");
- try { await SyncRecentVideos(20); } catch (e) {
- console.error("Light sync failed:", e);
- setSyncStatus("Sync failed");
- setTimeout(() => setSyncStatus(""), 3000);
- } finally { setIsSyncing(false); }
- };
+  const runSync = async (statusLabel: string, syncFn: () => Promise<unknown>, errorLabel: string) => {
+    if (isSyncing) return;
+    setShowSyncMenu(false);
+    setIsSyncing(true);
+    setSyncStatus(statusLabel);
+    try {
+      await syncFn();
+    } catch (e) {
+      console.error(errorLabel, e);
+      setSyncStatus("Sync failed");
+      setTimeout(() => setSyncStatus(""), 3000);
+    } finally {
+      setIsSyncing(false);
+    }
+  };
 
- const handleSyncFull = async () => {
- if (isSyncing) return;
- setShowSyncMenu(false); setIsSyncing(true);
- setSyncStatus("Full sync — fetching entire channel...");
- try { await SyncChannelData(); } catch (e) {
- console.error("Full sync failed:", e);
- setSyncStatus("Sync failed");
- setTimeout(() => setSyncStatus(""), 3000);
- } finally { setIsSyncing(false); }
- };
+  const handleSyncLight = () =>
+    runSync("Quick sync — last 20 videos...", () => SyncRecentVideos(20), "Light sync failed:");
+
+  const handleSyncFull = () =>
+    runSync("Full sync — fetching entire channel...", () => SyncChannelData(), "Full sync failed:");
 
  // Scroll sidebar to selected video
  useEffect(() => {

--- a/frontend/src/pages/__tests__/ChannelPage.test.tsx
+++ b/frontend/src/pages/__tests__/ChannelPage.test.tsx
@@ -19,13 +19,6 @@ vi.mock("../../../wailsjs/go/backend/App", () => ({
   UpdatePlaylistsVisibility: vi.fn().mockResolvedValue(undefined),
 }));
 
-// Mock IntersectionObserver
-(globalThis as any).IntersectionObserver = class IntersectionObserver {
-  observe() {}
-  unobserve() {}
-  disconnect() {}
-};
-
 // Mock runtime events
 const eventListeners: Record<string, Function[]> = {};
 

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,1 +1,17 @@
 import '@testing-library/jest-dom';
+
+class MockIntersectionObserver {
+  readonly root: Element | Document | null = null;
+  readonly rootMargin: string = '';
+  readonly thresholds: ReadonlyArray<number> = [];
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() { return []; }
+}
+
+Object.defineProperty(globalThis, 'IntersectionObserver', {
+  writable: true,
+  configurable: true,
+  value: MockIntersectionObserver,
+});


### PR DESCRIPTION
﻿### Summary of Changes
- Refactored YouTube sync invocation in `ChannelPage.tsx` into a reusable `runSync` higher-order function, eliminating boilerplate and unifying error/status state transitions.
- Centralized `IntersectionObserver` mock implementation into `frontend/src/test/setup.ts` to be shared globally across all test suites.
- Cleaned up local test boilerplate and redundant mocks in `frontend/src/pages/__tests__/ChannelPage.test.tsx`.

### Related
- Refs #25
