### PR TITLE
Fixed responsive subheader layout for Channel and Library pages (fixes #24)

### DIFF
--- a/frontend/src/components/video/LibrarySubHeader.tsx
+++ b/frontend/src/components/video/LibrarySubHeader.tsx
@@ -58,7 +58,7 @@ export default function LibrarySubHeader({
  return (
  <div className="flex flex-col border-b border-border-subtle bg-surface/50 backdrop-blur-md sticky top-0 z-20 shrink-0">
  {/* Top Row: Filters & Sort */}
- <div className="flex items-center justify-between px-6 h-14 shrink-0">
+ <div className="flex items-center justify-between px-6 min-h-14 py-2 shrink-0 flex-wrap gap-2">
  <div className="flex items-center gap-4 flex-wrap">
 
  {/* Folders */}

--- a/frontend/src/components/video/__tests__/LibrarySubHeader.test.tsx
+++ b/frontend/src/components/video/__tests__/LibrarySubHeader.test.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import LibrarySubHeader from "../LibrarySubHeader";
+
+describe("LibrarySubHeader", () => {
+  it("renders a responsive subheader without fixed height h-14", () => {
+    const dummyProps = {
+      folders: ["C:\\videos"],
+      activeFolders: [],
+      filteredVideos: [],
+      searchQuery: "",
+      sortMode: "date" as const,
+      onSearchChange: vi.fn(),
+      onSortChange: vi.fn(),
+      onToggleFolder: vi.fn(),
+      onOpenFolderSettings: vi.fn(),
+      filterUploaded: false,
+      onToggleFilterUploaded: vi.fn(),
+      advancedFilters: { dateFrom: "", dateTo: "", excludeWords: [] },
+      onAdvancedFiltersChange: vi.fn(),
+    };
+
+    const { container } = render(<LibrarySubHeader {...dummyProps} />);
+    const stickyHeaderInner = container.querySelector(".sticky.top-0 > div:first-child");
+    
+    expect(stickyHeaderInner).toBeInTheDocument();
+    expect(stickyHeaderInner).not.toHaveClass("h-14");
+    expect(stickyHeaderInner).toHaveClass("min-h-14");
+    expect(stickyHeaderInner).toHaveClass("py-2");
+  });
+});

--- a/frontend/src/pages/ChannelPage.tsx
+++ b/frontend/src/pages/ChannelPage.tsx
@@ -446,7 +446,7 @@ export default function ChannelPage() {
  <div className="flex-1 flex flex-col overflow-hidden bg-base">
  {/* ── Sticky sub-header ─────────────────────────────────────────────────── */}
  <div className="flex flex-col border-b border-border-subtle bg-surface/50 backdrop-blur-md sticky top-0 z-20 shrink-0">
- <div className="flex items-center gap-3 px-5 h-14 shrink-0 flex-wrap">
+ <div className="flex items-center gap-3 px-5 min-h-14 py-2 shrink-0 flex-wrap">
 
  {/* Breadcrumb / title */}
  {selectedPlaylist ? (

--- a/frontend/src/pages/__tests__/ChannelPage.test.tsx
+++ b/frontend/src/pages/__tests__/ChannelPage.test.tsx
@@ -203,4 +203,16 @@ describe("ChannelPage YouTube Sync State", () => {
       expect(lightSyncButton).not.toBeDisabled();
     });
   });
+  it("renders a responsive subheader without fixed height h-14", async () => {
+    const { container } = render(<ChannelPage />);
+    
+    // Wait for component to settle to avoid act() warnings
+    await screen.findByTitle("Light sync — fetch recent 20 videos");
+
+    const stickyHeader = container.querySelector(".sticky.top-0 > div");
+    expect(stickyHeader).toBeInTheDocument();
+    expect(stickyHeader).not.toHaveClass("h-14");
+    expect(stickyHeader).toHaveClass("min-h-14");
+    expect(stickyHeader).toHaveClass("py-2");
+  });
 });


### PR DESCRIPTION
﻿Closes #24

### Summary of Changes
- Converted fixed `h-14` height constraints to `min-h-14 py-2` on `ChannelPage` and `LibrarySubHeader` action toolbars to allow flexible vertical expansion.
- Ensured container flex settings (`flex-wrap`) cleanly accommodate sub-elements when wrapping on smaller resolutions.
- Added explicit unit tests to prevent regression of hardcoded height classes in layout headers.
- Fixed React `act()` warnings in `ChannelPage.test.tsx` by correctly waiting for async initialization to settle.
