### PR TITLE
Set default playlist visibility to public with dynamic persistence (fixes #17)

### DIFF
--- a/frontend/src/components/ui/TagPlaylistModal.tsx
+++ b/frontend/src/components/ui/TagPlaylistModal.tsx
@@ -1,127 +1,153 @@
 import React, { useState, useEffect } from "react";
 import { GetChannelPlaylists, GetOrCreatePlaylist, SetTagPlaylist } from "../../../wailsjs/go/backend/App";
-import { YTPlaylist } from "../../types";
+import { YTPlaylist, PlaylistPrivacy } from "../../types";
+import { useAppStore } from "../../store/useAppStore";
 
 interface Props {
- tag: string;
- onClose: () => void;
- onSaved: () => void;
+  tag: string;
+  onClose: () => void;
+  onSaved: () => void;
 }
 
 export default function TagPlaylistModal({ tag, onClose, onSaved }: Props) {
- const [playlists, setPlaylists] = useState<YTPlaylist[]>([]);
- const [isLoading, setIsLoading] = useState(true);
- const [isCreating, setIsCreating] = useState(false);
- const [newPlaylistTitle, setNewPlaylistTitle] = useState(tag); // default to tag name
- const [selectedPlaylistId, setSelectedPlaylistId] = useState("");
- const [error, setError] = useState("");
+  const [playlists, setPlaylists] = useState<YTPlaylist[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isCreating, setIsCreating] = useState(false);
+  const [newPlaylistTitle, setNewPlaylistTitle] = useState(tag); // default to tag name
+  const [privacy, setPrivacy] = useState<PlaylistPrivacy>(() => useAppStore.getState().defaultPlaylistPrivacy);
+  const [selectedPlaylistId, setSelectedPlaylistId] = useState("");
+  const [error, setError] = useState("");
 
- useEffect(() => {
- GetChannelPlaylists("recent")
- .then((res) => {
- setPlaylists(res || []);
- setIsLoading(false);
- })
- .catch((err) => {
- console.error(err);
- setIsLoading(false);
- });
- }, []);
+  const handlePrivacyChange = (newPrivacy: PlaylistPrivacy) => {
+    setPrivacy(newPrivacy);
+    useAppStore.setState({ defaultPlaylistPrivacy: newPrivacy });
+  };
 
- const handleCreateAndLink = async () => {
- if (!newPlaylistTitle.trim()) return;
- setIsCreating(true);
- setError("");
- try {
- const id = await GetOrCreatePlaylist(newPlaylistTitle.trim(), "", "public");
- await SetTagPlaylist(tag, id);
- onSaved();
- } catch (e: unknown) {
- setError(e instanceof Error ? e.message : String(e));
- setIsCreating(false);
- }
- };
+  useEffect(() => {
+    GetChannelPlaylists("recent")
+      .then((res) => {
+        setPlaylists(res || []);
+        setIsLoading(false);
+      })
+      .catch((err) => {
+        console.error(err);
+        setIsLoading(false);
+      });
+  }, []);
 
- const handleLinkExisting = async () => {
- if (!selectedPlaylistId) return;
- setIsCreating(true);
- setError("");
- try {
- await SetTagPlaylist(tag, selectedPlaylistId);
- onSaved();
- } catch (e: any) {
- setError(e.toString());
- setIsCreating(false);
- }
- };
+  const handleCreateAndLink = async () => {
+    if (!newPlaylistTitle.trim()) return;
+    setIsCreating(true);
+    setError("");
+    try {
+      useAppStore.setState({ defaultPlaylistPrivacy: privacy });
+      const id = await GetOrCreatePlaylist(newPlaylistTitle.trim(), "", privacy);
+      await SetTagPlaylist(tag, id);
+      onSaved();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+      setIsCreating(false);
+    }
+  };
 
- const handleSkip = async () => {
- // Set to "none" so it doesn't prompt again
- try {
- await SetTagPlaylist(tag, "none");
- } catch (e) {
- console.error(e);
- }
- onSaved();
- };
+  const handleLinkExisting = async () => {
+    if (!selectedPlaylistId) return;
+    setIsCreating(true);
+    setError("");
+    try {
+      await SetTagPlaylist(tag, selectedPlaylistId);
+      onSaved();
+    } catch (e: any) {
+      setError(e.toString());
+      setIsCreating(false);
+    }
+  };
 
- return (
- <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
- <div className="bg-surface border border-border-subtle rounded-lg shadow-2xl w-full max-w-md p-6 flex flex-col gap-4 animate-in fade-in zoom-in-95 duration-200">
- <div>
- <h2 className="text-lg font-bold text-text-primary m-0">Link Playlist to Tag</h2>
- <p className="text-sm text-text-secondary mt-1">
- You added a new tag <strong>"{tag}"</strong>. Link a YouTube playlist so future videos are auto-added to it — or skip if you don't want auto-linking for this tag.
- </p>
- </div>
+  const handleSkip = async () => {
+    // Set to "none" so it doesn't prompt again
+    try {
+      await SetTagPlaylist(tag, "none");
+    } catch (e) {
+      console.error(e);
+    }
+    onSaved();
+  };
 
- {error && (
- <div className="bg-red-500/10 border border-red-500/30 rounded p-2 text-xs text-red-400">
- {error}
- </div>
- )}
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <div className="bg-surface border border-border-subtle rounded-lg shadow-2xl w-full max-w-md p-6 flex flex-col gap-4 animate-in fade-in zoom-in-95 duration-200">
+        <div>
+          <h2 className="text-lg font-bold text-text-primary m-0">Link Playlist to Tag</h2>
+          <p className="text-sm text-text-secondary mt-1">
+            You added a new tag <strong>"{tag}"</strong>. Link a YouTube playlist so future videos are auto-added to it — or skip if you don't want auto-linking for this tag.
+          </p>
+        </div>
 
- {/* Skip option — prominently placed */}
- <button
- className="flex items-center gap-2 w-full px-4 py-2.5 rounded-md border border-border-subtle bg-elevated hover:bg-card hover:border-border-medium transition-colors text-sm font-medium text-text-secondary hover:text-text-primary text-left"
- onClick={handleSkip}
- disabled={isCreating}
- >
- <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="shrink-0 text-text-muted">
- <circle cx="12" cy="12" r="10" />
- <line x1="4.93" y1="4.93" x2="19.07" y2="19.07" />
- </svg>
- <span>No playlist for <strong>"{tag}"</strong> — don't ask again</span>
- </button>
+        {error && (
+          <div className="bg-red-500/10 border border-red-500/30 rounded p-2 text-xs text-red-400">
+            {error}
+          </div>
+        )}
 
- <div className="flex items-center gap-4">
- <div className="h-px bg-border-subtle flex-1" />
- <span className="text-xs text-text-muted font-bold tracking-wider">or link one</span>
- <div className="h-px bg-border-subtle flex-1" />
- </div>
+        {/* Skip option — prominently placed */}
+        <button
+          className="flex items-center gap-2 w-full px-4 py-2.5 rounded-md border border-border-subtle bg-elevated hover:bg-card hover:border-border-medium transition-colors text-sm font-medium text-text-secondary hover:text-text-primary text-left"
+          onClick={handleSkip}
+          disabled={isCreating}
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="shrink-0 text-text-muted">
+            <circle cx="12" cy="12" r="10" />
+            <line x1="4.93" y1="4.93" x2="19.07" y2="19.07" />
+          </svg>
+          <span>No playlist for <strong>"{tag}"</strong> — don't ask again</span>
+        </button>
 
- <div className="flex flex-col gap-3">
- <div className="flex flex-col gap-1.5 p-3 border border-border-subtle rounded bg-elevated">
- <label className="text-xs font-bold text-text-secondary">Create New Playlist</label>
- <div className="flex gap-2 items-center">
- <input
- className="flex-1 min-w-0 h-[38px] bg-surface border border-border-subtle rounded-sm px-3 text-sm text-text-primary outline-none focus:border-accent"
- type="text"
- value={newPlaylistTitle}
- onChange={(e) => setNewPlaylistTitle(e.target.value)}
- placeholder="Playlist name..."
- disabled={isCreating}
- autoFocus
- />
- <button
- className="btn btn-primary h-[36px] px-3.5 text-xs font-semibold whitespace-nowrap shrink-0"
- onClick={handleCreateAndLink}
- disabled={!newPlaylistTitle.trim() || isCreating}
- >
- Create & Link
- </button>
- </div>
- </div>
+        <div className="flex items-center gap-4">
+          <div className="h-px bg-border-subtle flex-1" />
+          <span className="text-xs text-text-muted font-bold tracking-wider">or link one</span>
+          <div className="h-px bg-border-subtle flex-1" />
+        </div>
+
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-2 p-3 border border-border-subtle rounded bg-elevated">
+            <label className="text-xs font-bold text-text-secondary">Create New Playlist</label>
+            <div className="flex gap-2 items-center">
+              <input
+                className="flex-1 min-w-0 h-[38px] bg-surface border border-border-subtle rounded-sm px-3 text-sm text-text-primary outline-none focus:border-accent"
+                type="text"
+                value={newPlaylistTitle}
+                onChange={(e) => setNewPlaylistTitle(e.target.value)}
+                placeholder="Playlist name..."
+                disabled={isCreating}
+                autoFocus
+              />
+              <button
+                className="btn btn-primary h-[36px] px-3.5 text-xs font-semibold whitespace-nowrap shrink-0"
+                onClick={handleCreateAndLink}
+                disabled={!newPlaylistTitle.trim() || isCreating}
+              >
+                Create & Link
+              </button>
+            </div>
+            <div className="flex items-center gap-1.5 pt-1">
+              <span className="text-[11px] text-text-muted mr-1 font-medium">Visibility:</span>
+              {(["public", "unlisted", "private"] as const).map((p) => (
+                <button
+                  key={p}
+                  type="button"
+                  onClick={() => handlePrivacyChange(p)}
+                  disabled={isCreating}
+                  className={`px-2.5 py-1 text-xs font-medium rounded border transition-colors ${
+                    privacy === p
+                      ? "bg-card border-accent text-accent"
+                      : "bg-surface border-border-subtle text-text-secondary hover:text-text-primary hover:border-border-medium"
+                  }`}
+                >
+                  {p.charAt(0).toUpperCase() + p.slice(1)}
+                </button>
+              ))}
+            </div>
+          </div>
 
  <div className="flex flex-col gap-1.5 p-3 border border-border-subtle rounded bg-elevated">
  <label className="text-xs font-bold text-text-secondary">Link Existing Playlist</label>

--- a/frontend/src/components/ui/__tests__/TagPlaylistModal.test.tsx
+++ b/frontend/src/components/ui/__tests__/TagPlaylistModal.test.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import TagPlaylistModal from "../TagPlaylistModal";
+import * as appBackend from "../../../../wailsjs/go/backend/App";
+import { useAppStore } from "../../../store/useAppStore";
+
+vi.mock("../../../../wailsjs/go/backend/App", () => ({
+  GetChannelPlaylists: vi.fn().mockResolvedValue([]),
+  GetOrCreatePlaylist: vi.fn().mockResolvedValue("pl-123"),
+  SetTagPlaylist: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe("TagPlaylistModal", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+    useAppStore.setState({ defaultPlaylistPrivacy: "public" });
+  });
+
+  it("should create playlist with default 'public' privacy when no preference is stored", async () => {
+    const onClose = vi.fn();
+    const onSaved = vi.fn();
+
+    render(<TagPlaylistModal tag="Valorant" onClose={onClose} onSaved={onSaved} />);
+
+    // Check that privacy option Public is selected by default
+    const publicBtn = screen.getByRole("button", { name: /public/i });
+    expect(publicBtn).toBeInTheDocument();
+
+    const createBtn = screen.getByRole("button", { name: /create & link/i });
+    fireEvent.click(createBtn);
+
+    await waitFor(() => {
+      expect(appBackend.GetOrCreatePlaylist).toHaveBeenCalledWith("Valorant", "", "public");
+      expect(appBackend.SetTagPlaylist).toHaveBeenCalledWith("Valorant", "pl-123");
+      expect(onSaved).toHaveBeenCalled();
+    });
+  });
+
+  it("should allow changing privacy, persist it, and create playlist with updated privacy", async () => {
+    const onClose = vi.fn();
+    const onSaved = vi.fn();
+
+    render(<TagPlaylistModal tag="Overwatch" onClose={onClose} onSaved={onSaved} />);
+
+    const unlistedBtn = screen.getByRole("button", { name: /unlisted/i });
+    fireEvent.click(unlistedBtn);
+
+    expect(useAppStore.getState().defaultPlaylistPrivacy).toBe("unlisted");
+
+    const createBtn = screen.getByRole("button", { name: /create & link/i });
+    fireEvent.click(createBtn);
+
+    await waitFor(() => {
+      expect(appBackend.GetOrCreatePlaylist).toHaveBeenCalledWith("Overwatch", "", "unlisted");
+      expect(appBackend.SetTagPlaylist).toHaveBeenCalledWith("Overwatch", "pl-123");
+      expect(onSaved).toHaveBeenCalled();
+    });
+  });
+
+  it("should initialize privacy selector from stored preference across sessions", async () => {
+    useAppStore.setState({ defaultPlaylistPrivacy: "private" });
+    const onClose = vi.fn();
+    const onSaved = vi.fn();
+
+    render(<TagPlaylistModal tag="Minecraft" onClose={onClose} onSaved={onSaved} />);
+
+    const createBtn = screen.getByRole("button", { name: /create & link/i });
+    fireEvent.click(createBtn);
+
+    await waitFor(() => {
+      expect(appBackend.GetOrCreatePlaylist).toHaveBeenCalledWith("Minecraft", "", "private");
+    });
+  });
+});

--- a/frontend/src/components/video/BulkActionBar.tsx
+++ b/frontend/src/components/video/BulkActionBar.tsx
@@ -11,6 +11,7 @@ import { useRecentTags } from "../../hooks/useRecentTags";
 import { useRecentFieldValues } from "../../hooks/useRecentFieldValues";
 import { VideoFile, YTPlaylist, GameProfile } from "../../types";
 import { generateYouTubeTitle, extractCustomVars } from "../../utils/videoUtils";
+import { useAppStore } from "../../store/useAppStore";
 import TagInput from "../ui/TagInput";
 import TagPlaylistModal from "../ui/TagPlaylistModal";
 
@@ -184,7 +185,7 @@ export default function BulkActionBar({
  setCreatingNewLoading(true);
  try {
  // Use GetOrCreatePlaylist to avoid duplicate playlists with the same name
- const newId = await GetOrCreatePlaylist(title, "", "public");
+ const newId = await GetOrCreatePlaylist(title, "", useAppStore.getState().defaultPlaylistPrivacy);
  if (newId) {
  await handleSavePlaylist(newId, title);
  setNewPlaylistTitle("");

--- a/frontend/src/components/video/InlinePlayer.tsx
+++ b/frontend/src/components/video/InlinePlayer.tsx
@@ -9,6 +9,8 @@ import { setCachedThumb, clearCachedPreview } from "../../hooks/useThumbnailQueu
 import TagInput from "../ui/TagInput";
 import TagPlaylistModal from "../ui/TagPlaylistModal";
 import FieldInput from "../ui/FieldInput";
+import { useAppStore } from "../../store/useAppStore";
+import { PlaylistPrivacy } from "../../types";
 
 interface InlinePlayerProps {
  video: VideoFile;
@@ -162,9 +164,9 @@ export default function InlinePlayer({ video, streamPort, selectedPaths = [], on
  const [gameModeInput, setGameModeInput] = useState(video.gameMode || "");
  const [customVarsInput, setCustomVarsInput] = useState<Record<string, string>>(video.customVars || {});
  const [description, setDescription] = useState(video.description || "");
- const [privacy, setPrivacy] = useState<"public" | "unlisted" | "private">(
- (video.privacy as "public" | "unlisted" | "private") || "unlisted"
- );
+ const [privacy, setPrivacy] = useState<PlaylistPrivacy>(
+    (video.privacy as PlaylistPrivacy) || useAppStore.getState().defaultPlaylistPrivacy
+  );
  const [playlistId, setPlaylistId] = useState(video.playlistId || "");
  const [playlists, setPlaylists] = useState<YTPlaylist[]>([]);
  const [isCreatingPlaylist, setIsCreatingPlaylist] = useState(false);
@@ -201,7 +203,7 @@ export default function InlinePlayer({ video, streamPort, selectedPaths = [], on
  setEventInput(video.event || "");
  setGameModeInput(video.gameMode || "");
  setDescription(video.description || "");
- setPrivacy((video.privacy as "public" | "unlisted" | "private") || "unlisted");
+ setPrivacy((video.privacy as PlaylistPrivacy) || useAppStore.getState().defaultPlaylistPrivacy);
  setPlaylistId(video.playlistId || "");
  setPlaylistSearch(video.playlistTitle || "");
  }, [video.path, video.youtubeTitle, video.game, video.description, video.privacy, video.playlistId, video.episode, video.event, video.gameMode, gameProfiles]);
@@ -228,6 +230,7 @@ export default function InlinePlayer({ video, streamPort, selectedPaths = [], on
  setIsCreatingPlaylistLoading(true);
  setPlaylistCreateError("");
  try {
+ useAppStore.setState({ defaultPlaylistPrivacy: privacy });
  const id = await GetOrCreatePlaylist(newPlaylistTitle.trim(), "", privacy);
  setNewPlaylistTitle("");
  setIsCreatingPlaylist(false);
@@ -802,7 +805,7 @@ export default function InlinePlayer({ video, streamPort, selectedPaths = [], on
  <label className="text-sm font-medium text-white/90">Privacy</label>
  <div className="flex gap-2">
  {(["public", "unlisted", "private"] as const).map(p => (
- <button key={p} className={`flex-1 py-2 rounded-sm text-sm font-medium transition-colors border ${privacy === p ? "bg-card border-accent text-accent " : "bg-elevated border-border-subtle text-text-primary hover:border-border-medium hover:bg-card"}`} onClick={() => setPrivacy(p)}>{p.charAt(0).toUpperCase() + p.slice(1)}</button>
+ <button key={p} className={`flex-1 py-2 rounded-sm text-sm font-medium transition-colors border ${privacy === p ? "bg-card border-accent text-accent " : "bg-elevated border-border-subtle text-text-primary hover:border-border-medium hover:bg-card"}`} onClick={() => { setPrivacy(p); useAppStore.setState({ defaultPlaylistPrivacy: p }); }}>{p.charAt(0).toUpperCase() + p.slice(1)}</button>
  ))}
  </div>
  </div>
@@ -1052,7 +1055,7 @@ export default function InlinePlayer({ video, streamPort, selectedPaths = [], on
  <label className="text-sm font-medium text-white/90">Privacy</label>
  <div className="flex gap-2">
  {(["public", "unlisted", "private"] as const).map(p => (
- <button key={p} className={`px-6 py-2 rounded-sm text-sm font-medium transition-colors border ${privacy === p ? "bg-card border-accent text-accent " : "bg-elevated border-border-subtle text-text-primary hover:border-border-medium hover:bg-card"}`} onClick={() => setPrivacy(p)}>{p.charAt(0).toUpperCase() + p.slice(1)}</button>
+ <button key={p} className={`px-6 py-2 rounded-sm text-sm font-medium transition-colors border ${privacy === p ? "bg-card border-accent text-accent " : "bg-elevated border-border-subtle text-text-primary hover:border-border-medium hover:bg-card"}`} onClick={() => { setPrivacy(p); useAppStore.setState({ defaultPlaylistPrivacy: p }); }}>{p.charAt(0).toUpperCase() + p.slice(1)}</button>
  ))}
  </div>
  </div>

--- a/frontend/src/components/youtube/UploadDialog.tsx
+++ b/frontend/src/components/youtube/UploadDialog.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from "react";
 import { VideoFile, YTPlaylist, GameProfile } from "../../types";
 import { generateYouTubeTitle } from "../../utils/videoUtils";
+import { useAppStore } from "../../store/useAppStore";
+import { PlaylistPrivacy } from "../../types";
 import { QueueItem } from "./UploadQueue";
 import {
  GetChannelPlaylists,
@@ -11,7 +13,7 @@ import {
 export interface UploadOptions {
  title: string;
  description: string;
- privacy: "public" | "unlisted" | "private";
+ privacy: PlaylistPrivacy;
  playlistId?: string;
 }
 
@@ -51,8 +53,8 @@ export default function UploadDialog({
  ),
  );
  const [description, setDescription] = useState(video.description || "");
- const [privacy, setPrivacy] = useState<"public" | "unlisted" | "private">(
- (video.privacy as "public" | "unlisted" | "private") || "unlisted",
+ const [privacy, setPrivacy] = useState<PlaylistPrivacy>(
+ (video.privacy as PlaylistPrivacy) || useAppStore.getState().defaultPlaylistPrivacy,
  );
  const [playlistId, setPlaylistId] = useState(video.playlistId || "");
  const [playlists, setPlaylists] = useState<YTPlaylist[]>([]);
@@ -107,24 +109,25 @@ export default function UploadDialog({
  }
  }, [playlists, playlistId]);
 
- const handleCreatePlaylist = async () => {
- if (!newPlaylistTitle.trim()) return;
- setIsCreatingPlaylist(true);
- setPlaylistError("");
- try {
- const id = await GetOrCreatePlaylist(newPlaylistTitle.trim(), "", privacy);
- // Refresh from DB — the backend already persisted the playlist row
- await refreshPlaylists();
- setNewPlaylistTitle("");
- setIsCreating(false);
- setPlaylistId(id);
- setPlaylistSearch(newPlaylistTitle.trim());
- } catch (e: any) {
- setPlaylistError(e?.toString() ?? "Failed to get or create playlist");
- } finally {
- setIsCreatingPlaylist(false);
- }
- };
+  const handleCreatePlaylist = async () => {
+    if (!newPlaylistTitle.trim()) return;
+    setIsCreatingPlaylist(true);
+    setPlaylistError("");
+    try {
+      useAppStore.setState({ defaultPlaylistPrivacy: privacy });
+      const id = await GetOrCreatePlaylist(newPlaylistTitle.trim(), "", privacy);
+      // Refresh from DB — the backend already persisted the playlist row
+      await refreshPlaylists();
+      setNewPlaylistTitle("");
+      setIsCreating(false);
+      setPlaylistId(id);
+      setPlaylistSearch(newPlaylistTitle.trim());
+    } catch (e: any) {
+      setPlaylistError(e?.toString() ?? "Failed to get or create playlist");
+    } finally {
+      setIsCreatingPlaylist(false);
+    }
+  };
 
  const opts = (): UploadOptions => ({
  title,
@@ -366,7 +369,10 @@ export default function UploadDialog({
  <button
  key={p}
  className={`flex-1 flex flex-col items-center justify-center gap-1.5 py-3 rounded-sm text-xs font-semibold cursor-pointer transition-colors ${privacy === p ? "bg-accent text-white border border-accent hover:bg-accent" : "bg-elevated border border-border-subtle text-text-secondary hover:bg-card hover:border-border-medium hover:text-text-primary"}`}
- onClick={() => setPrivacy(p)}
+ onClick={() => {
+ setPrivacy(p);
+ useAppStore.setState({ defaultPlaylistPrivacy: p });
+ }}
  >
  {p === "public" && (
  <svg

--- a/frontend/src/store/useAppStore.ts
+++ b/frontend/src/store/useAppStore.ts
@@ -4,20 +4,21 @@
  */
 import { useSyncExternalStore } from "react";
 import { QueueItem } from "../components/youtube/UploadQueue";
-import { ViewMode } from "../types";
+import { ViewMode, PlaylistPrivacy } from "../types";
 
 type SortMode = "date" | "name" | "size";
 
 interface AppState {
- queue: QueueItem[];
- queueRunning: boolean;
- queueAddedAt: number; // timestamp bump — changes every time an item is added
- queueDoneAt: number; // timestamp bump — changes every time an item finishes
- ytAuthed: boolean;
- view: ViewMode;
- sortMode: SortMode;
- filterUploaded: boolean;
- selectedIndex: number;
+  queue: QueueItem[];
+  queueRunning: boolean;
+  queueAddedAt: number; // timestamp bump — changes every time an item is added
+  queueDoneAt: number; // timestamp bump — changes every time an item finishes
+  ytAuthed: boolean;
+  view: ViewMode;
+  sortMode: SortMode;
+  filterUploaded: boolean;
+  selectedIndex: number;
+  defaultPlaylistPrivacy: PlaylistPrivacy;
 }
 
 // ─── Persistence helpers ──────────────────────────────────────────────────────
@@ -25,26 +26,27 @@ interface AppState {
 const PREFS_KEY = "amon-hen-prefs";
 
 function loadPersistedPrefs(): Partial<AppState> {
- try {
- const raw = localStorage.getItem(PREFS_KEY);
- return raw ? JSON.parse(raw) : {};
- } catch {
- return {};
- }
+  try {
+    const raw = localStorage.getItem(PREFS_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
 }
 
 function savePersistedPrefs(state: AppState) {
- try {
- localStorage.setItem(
- PREFS_KEY,
- JSON.stringify({
- view: state.view,
- sortMode: state.sortMode,
- filterUploaded: state.filterUploaded,
- selectedIndex: state.selectedIndex,
- })
- );
- } catch {}
+  try {
+    localStorage.setItem(
+      PREFS_KEY,
+      JSON.stringify({
+        view: state.view,
+        sortMode: state.sortMode,
+        filterUploaded: state.filterUploaded,
+        selectedIndex: state.selectedIndex,
+        defaultPlaylistPrivacy: state.defaultPlaylistPrivacy,
+      })
+    );
+  } catch {}
 }
 
 // ─── Store implementation ─────────────────────────────────────────────────────
@@ -52,64 +54,67 @@ function savePersistedPrefs(state: AppState) {
 const saved = loadPersistedPrefs();
 
 let state: AppState = {
- queue: [],
- queueRunning: false,
- queueAddedAt: 0,
- queueDoneAt: 0,
- ytAuthed: false,
- view: (saved.view as ViewMode) ?? "grid",
- sortMode: (saved.sortMode as SortMode) ?? "date",
- filterUploaded: saved.filterUploaded ?? false,
- selectedIndex: saved.selectedIndex ?? -1,
+  queue: [],
+  queueRunning: false,
+  queueAddedAt: 0,
+  queueDoneAt: 0,
+  ytAuthed: false,
+  view: (saved.view as ViewMode) ?? "grid",
+  sortMode: (saved.sortMode as SortMode) ?? "date",
+  filterUploaded: saved.filterUploaded ?? false,
+  selectedIndex: saved.selectedIndex ?? -1,
+  defaultPlaylistPrivacy: (saved.defaultPlaylistPrivacy as PlaylistPrivacy) ?? "public",
 };
 
 type Listener = () => void;
 const listeners = new Set<Listener>();
 
 function getSnapshot() {
- return state;
+  return state;
 }
 
 function setState(patch: Partial<AppState> | ((prev: AppState) => Partial<AppState>)) {
- const incoming = typeof patch === "function" ? patch(state) : patch;
- state = { ...state, ...incoming };
- savePersistedPrefs(state);
- listeners.forEach((l) => l());
+  const incoming = typeof patch === "function" ? patch(state) : patch;
+  state = { ...state, ...incoming };
+  savePersistedPrefs(state);
+  listeners.forEach((l) => l());
 }
 
 function subscribe(listener: Listener) {
- listeners.add(listener);
- return () => listeners.delete(listener);
+  listeners.add(listener);
+  return () => listeners.delete(listener);
 }
 
 // ─── React hook ───────────────────────────────────────────────────────────────
 
 export function useAppStore() {
- const s = useSyncExternalStore(subscribe, getSnapshot);
+  const s = useSyncExternalStore(subscribe, getSnapshot);
 
- const setQueue = (queueOrUpdater: QueueItem[] | ((prev: QueueItem[]) => QueueItem[])) => {
- setState((prev) => ({
- queue:
- typeof queueOrUpdater === "function"
- ? queueOrUpdater(prev.queue)
- : queueOrUpdater,
- }));
- };
+  const setQueue = (queueOrUpdater: QueueItem[] | ((prev: QueueItem[]) => QueueItem[])) => {
+    setState((prev) => ({
+      queue:
+        typeof queueOrUpdater === "function"
+          ? queueOrUpdater(prev.queue)
+          : queueOrUpdater,
+    }));
+  };
 
- return {
- ...s,
- setQueue,
- addToQueue: (items: QueueItem[]) =>
- setState((prev) => ({ queue: [...prev.queue, ...items], queueAddedAt: Date.now() })),
- bumpQueueAdded: () => setState({ queueAddedAt: Date.now() }),
- bumpQueueDone: () => setState({ queueDoneAt: Date.now() }),
- setQueueRunning: (queueRunning: boolean) => setState({ queueRunning }),
- setYtAuthed: (ytAuthed: boolean) => setState({ ytAuthed }),
- setView: (view: ViewMode) => setState({ view }),
- setSortMode: (sortMode: SortMode) => setState({ sortMode }),
- setFilterUploaded: (filterUploaded: boolean) => setState({ filterUploaded }),
- setSelectedIndex: (selectedIndex: number) => setState({ selectedIndex }),
- };
+  return {
+    ...s,
+    setQueue,
+    addToQueue: (items: QueueItem[]) =>
+      setState((prev) => ({ queue: [...prev.queue, ...items], queueAddedAt: Date.now() })),
+    bumpQueueAdded: () => setState({ queueAddedAt: Date.now() }),
+    bumpQueueDone: () => setState({ queueDoneAt: Date.now() }),
+    setQueueRunning: (queueRunning: boolean) => setState({ queueRunning }),
+    setYtAuthed: (ytAuthed: boolean) => setState({ ytAuthed }),
+    setView: (view: ViewMode) => setState({ view }),
+    setSortMode: (sortMode: SortMode) => setState({ sortMode }),
+    setFilterUploaded: (filterUploaded: boolean) => setState({ filterUploaded }),
+    setSelectedIndex: (selectedIndex: number) => setState({ selectedIndex }),
+    setDefaultPlaylistPrivacy: (defaultPlaylistPrivacy: PlaylistPrivacy) =>
+      setState({ defaultPlaylistPrivacy }),
+  };
 }
 
 useAppStore.getState = getSnapshot;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -80,3 +80,4 @@ export interface FolderConfig {
 }
 
 export type ViewMode = "grid" | "player" | "channel" | "queue" | "stats" | "steam";
+export type PlaylistPrivacy = "public" | "unlisted" | "private";


### PR DESCRIPTION
﻿Closes #17

### Summary of Changes
- Updated the default playlist visibility preference across the application to `public`.
- Integrated `defaultPlaylistPrivacy` into `useAppStore` to dynamically persist playlist privacy preferences in local storage (`amon-hen-prefs`).
- Added privacy selection toggle controls to `TagPlaylistModal` so users can explicitly set and persist visibility when creating tagged playlists.
- Updated `InlinePlayer`, `UploadDialog`, and `BulkActionBar` to use the stored default playlist privacy on initial load and update it when adjusted.
- Added comprehensive unit tests for `TagPlaylistModal` privacy defaults and dynamic persistence.

### Verification
- `npm run test` (13/13 passing)
- `npm run build` (Clean TypeScript & Vite compilation)
