### PR TITLE
Add duplicate video warning indicators in playlist view (fixes #34)

### DIFF
--- a/backend/database.go
+++ b/backend/database.go
@@ -60,11 +60,13 @@ func (db *DB) migrate() error {
 			privacy TEXT
 		)`,
 		`CREATE TABLE IF NOT EXISTS yt_playlist_items (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			playlist_id TEXT,
 			video_id TEXT,
-			position INTEGER,
-			PRIMARY KEY (playlist_id, video_id)
+			position INTEGER
 		)`,
+		`CREATE INDEX IF NOT EXISTS idx_yt_playlist_items_pl ON yt_playlist_items(playlist_id, position)`,
+		`CREATE INDEX IF NOT EXISTS idx_yt_playlist_items_vid ON yt_playlist_items(video_id)`,
 		`CREATE TABLE IF NOT EXISTS api_logs (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			ts INTEGER NOT NULL,
@@ -116,6 +118,42 @@ func (db *DB) migrate() error {
 	db.conn.Exec("ALTER TABLE yt_playlists ADD COLUMN privacy TEXT")
 	db.conn.Exec("ALTER TABLE yt_videos ADD COLUMN game_tag TEXT")
 	db.conn.Exec("ALTER TABLE yt_videos ADD COLUMN episode INTEGER")
+
+	// Migrate yt_playlist_items if legacy composite primary key exists
+	var isCompositePK bool
+	rows, pErr := db.conn.Query("PRAGMA table_info(yt_playlist_items)")
+	if pErr == nil {
+		var pkCount int
+		for rows.Next() {
+			var cid int
+			var name, ctype string
+			var notnull, pk int
+			var dfltValue sql.NullString
+			if err := rows.Scan(&cid, &name, &ctype, &notnull, &dfltValue, &pk); err == nil {
+				if pk > 0 && (name == "playlist_id" || name == "video_id") {
+					pkCount++
+				}
+			}
+		}
+		rows.Close()
+		if pkCount >= 2 {
+			isCompositePK = true
+		}
+	}
+	if isCompositePK {
+		db.conn.Exec(`
+			CREATE TABLE IF NOT EXISTS yt_playlist_items_new (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				playlist_id TEXT,
+				video_id TEXT,
+				position INTEGER
+			);
+			INSERT INTO yt_playlist_items_new (playlist_id, video_id, position)
+			SELECT playlist_id, video_id, position FROM yt_playlist_items;
+			DROP TABLE yt_playlist_items;
+			ALTER TABLE yt_playlist_items_new RENAME TO yt_playlist_items;
+		`)
+	}
 
 	for _, q := range queries {
 		if _, err := db.conn.Exec(q); err != nil {

--- a/backend/youtube.go
+++ b/backend/youtube.go
@@ -737,8 +737,7 @@ func (a *App) UploadToYouTube(path, title, description, privacy, playlistID, gam
 			a.db.mu.Lock()
 			a.db.conn.Exec(`
 				INSERT INTO yt_playlist_items (playlist_id, video_id, position)
-				VALUES (?, ?, (SELECT COALESCE(MAX(position)+1, 0) FROM yt_playlist_items WHERE playlist_id=?))
-				ON CONFLICT(playlist_id, video_id) DO NOTHING`,
+				VALUES (?, ?, (SELECT COALESCE(MAX(position)+1, 0) FROM yt_playlist_items WHERE playlist_id=?))`,
 				playlistID, result.Id, playlistID)
 			a.db.conn.Exec(
 				`UPDATE yt_playlists SET video_count = video_count + 1 WHERE id = ?`,

--- a/backend/youtube_sync.go
+++ b/backend/youtube_sync.go
@@ -331,6 +331,11 @@ func (a *App) UpdateYouTubeVideoMetadata(videoID, title, description, privacy st
 }
 
 func (a *App) syncPlaylistItems(svc *youtube.Service, playlistID string) error {
+	type itemEntry struct {
+		videoID  string
+		position int64
+	}
+	var items []itemEntry
 	pageToken := ""
 	for {
 		call := svc.PlaylistItems.List([]string{"snippet", "contentDetails"}).PlaylistId(playlistID).MaxResults(50)
@@ -346,10 +351,10 @@ func (a *App) syncPlaylistItems(svc *youtube.Service, playlistID string) error {
 		}
 
 		for _, item := range resp.Items {
-			a.db.conn.Exec(`INSERT INTO yt_playlist_items (playlist_id, video_id, position)
-				VALUES (?, ?, ?)
-				ON CONFLICT(playlist_id, video_id) DO UPDATE SET position=excluded.position`,
-				playlistID, item.ContentDetails.VideoId, item.Snippet.Position)
+			items = append(items, itemEntry{
+				videoID:  item.ContentDetails.VideoId,
+				position: item.Snippet.Position,
+			})
 		}
 
 		if resp.NextPageToken == "" {
@@ -357,7 +362,33 @@ func (a *App) syncPlaylistItems(svc *youtube.Service, playlistID string) error {
 		}
 		pageToken = resp.NextPageToken
 	}
-	return nil
+
+	a.db.mu.Lock()
+	defer a.db.mu.Unlock()
+
+	tx, err := a.db.conn.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.Exec("DELETE FROM yt_playlist_items WHERE playlist_id = ?", playlistID); err != nil {
+		return err
+	}
+
+	stmt, err := tx.Prepare("INSERT INTO yt_playlist_items (playlist_id, video_id, position) VALUES (?, ?, ?)")
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+
+	for _, it := range items {
+		if _, err := stmt.Exec(playlistID, it.videoID, it.position); err != nil {
+			appLog("[syncPlaylistItems] Error inserting item %s into playlist %s: %v", it.videoID, playlistID, err)
+		}
+	}
+
+	return tx.Commit()
 }
 
 // syncVideos fetches all videos from the uploads playlist and upserts them into SQLite.

--- a/frontend/src/components/video/VideoPill.tsx
+++ b/frontend/src/components/video/VideoPill.tsx
@@ -39,6 +39,7 @@ interface VideoPillProps {
 	gameProfiles?: Record<string, GameProfile>;
 	onThumbLoaded?: (url: string) => void;
 	onSelectToggle?: (e: React.MouseEvent) => void;
+	duplicateCount?: number;
 }
 
 export default function VideoPill({
@@ -56,6 +57,7 @@ export default function VideoPill({
 	gameProfiles = {},
 	onThumbLoaded,
 	onSelectToggle,
+	duplicateCount,
 }: VideoPillProps) {
 	const ref = useRef<HTMLDivElement>(null);
 	const inView = useInView(ref);
@@ -262,6 +264,20 @@ export default function VideoPill({
  </svg>
  </div>
  </div>
+
+        {/* Duplicate Warning Badge */}
+        {duplicateCount !== undefined && duplicateCount > 1 && (
+          <div
+            className="absolute top-2 right-2 bg-amber-500 text-black px-1.5 py-0.5 rounded text-[10px] font-bold z-20 flex items-center gap-1 border border-amber-400/40"
+            title={`Duplicate video (${duplicateCount} occurrences in this playlist)`}
+          >
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+            </svg>
+            <span>Duplicate ({duplicateCount}x)</span>
+          </div>
+        )}
 
  {/* Duration Badge */}
  {displayDuration && (

--- a/frontend/src/components/video/__tests__/VideoPill.test.tsx
+++ b/frontend/src/components/video/__tests__/VideoPill.test.tsx
@@ -1,0 +1,50 @@
+﻿import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import VideoPill from "../VideoPill";
+import { YTVideo } from "../../../types";
+
+// Mock Wails backend App calls
+vi.mock("../../../../wailsjs/go/backend/App", () => ({
+  GetThumbnail: vi.fn().mockResolvedValue(""),
+  GetVideoPreview: vi.fn().mockResolvedValue(""),
+  GetVideoDuration: vi.fn().mockResolvedValue(0),
+}));
+
+const mockVideo: YTVideo = {
+  id: "test-vid-1",
+  title: "Episode 10 - Boss Fight",
+  description: "Test description",
+  publishedAt: "2026-01-01T00:00:00Z",
+  thumbnailUrl: "https://example.com/thumb.jpg",
+  viewCount: 1500,
+  likeCount: 120,
+  duration: "PT10M15S",
+  privacy: "public",
+  localFile: "",
+};
+
+describe("VideoPill Duplicate Indicator", () => {
+  it("renders duplicate badge when duplicateCount > 1 in grid view", () => {
+    render(<VideoPill video={mockVideo} duplicateCount={2} viewMode="grid" />);
+
+    const badge = screen.getByText("Duplicate (2x)");
+    expect(badge).toBeInTheDocument();
+  });
+
+  it("renders duplicate badge when duplicateCount > 1 in list view", () => {
+    render(<VideoPill video={mockVideo} duplicateCount={3} viewMode="list" />);
+
+    const badge = screen.getByText("Duplicate (3x)");
+    expect(badge).toBeInTheDocument();
+  });
+
+  it("does not render duplicate badge when duplicateCount is undefined or <= 1", () => {
+    const { rerender } = render(<VideoPill video={mockVideo} viewMode="grid" />);
+    expect(screen.queryByText(/Duplicate/i)).not.toBeInTheDocument();
+
+    rerender(<VideoPill video={mockVideo} duplicateCount={1} viewMode="grid" />);
+    expect(screen.queryByText(/Duplicate/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/hooks/useChannelData.ts
+++ b/frontend/src/hooks/useChannelData.ts
@@ -200,13 +200,14 @@ export function useChannelData({
  }
 
  return {
- videos,
- playlists,
- filteredVideos,
- loading,
- loadingMore,
- hasMore,
- loadMoreRef,
- loadData,
+  videos,
+  playlists,
+  playlistVideos,
+  filteredVideos,
+  loading,
+  loadingMore,
+  hasMore,
+  loadMoreRef,
+  loadData,
  };
 }

--- a/frontend/src/pages/ChannelPage.tsx
+++ b/frontend/src/pages/ChannelPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import { YTVideo, YTPlaylist, VideoGroupYT } from "../types";
 import { SyncRecentVideos, SyncChannelData, GetSyncStatus, IsYouTubeAuthed, GetPlaylistVideos, AddVideoToPlaylist, PurgePlaylistDuplicates, UpdatePlaylistsVisibility } from "../../wailsjs/go/backend/App";
 import { EventsOn, EventsOff } from "../../wailsjs/runtime/runtime";
@@ -106,19 +106,39 @@ export default function ChannelPage() {
     return () => window.removeEventListener("keydown", handleEscape);
   }, [selectedPlaylistIds.size, selectedVideoIds.size, searchQuery]);
 
- const {
- videos, playlists, filteredVideos, loading, loadingMore, loadMoreRef, loadData,
- } = useChannelData({
- activeTab,
- videoSort,
- playlistSort,
- debouncedSearch,
- selectedPlaylist,
- dateFilter: analyticsDate,
- dateFrom: analyticsDate ? undefined : filters.dateFrom,
- dateTo: analyticsDate ? undefined : filters.dateTo,
- excludeWords: filters.excludeWords,
- });
+  const {
+    videos, playlists, playlistVideos, filteredVideos, loading, loadingMore, loadMoreRef, loadData,
+  } = useChannelData({
+    activeTab,
+    videoSort,
+    playlistSort,
+    debouncedSearch,
+    selectedPlaylist,
+    dateFilter: analyticsDate,
+    dateFrom: analyticsDate ? undefined : filters.dateFrom,
+    dateTo: analyticsDate ? undefined : filters.dateTo,
+    excludeWords: filters.excludeWords,
+  });
+
+  const playlistVideoCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    if (!selectedPlaylist) return counts;
+    for (const v of playlistVideos) {
+      if (!v.id) continue;
+      counts.set(v.id, (counts.get(v.id) || 0) + 1);
+    }
+    return counts;
+  }, [selectedPlaylist, playlistVideos]);
+
+  const duplicateEntriesCount = useMemo(() => {
+    let excess = 0;
+    for (const count of playlistVideoCounts.values()) {
+      if (count > 1) {
+        excess += count - 1;
+      }
+    }
+    return excess;
+  }, [playlistVideoCounts]);
 
   // Sync events
   useEffect(() => {
@@ -472,6 +492,19 @@ export default function ChannelPage() {
  <span className="text-[9px] font-bold text-accent leading-none mb-0.5 group-hover:text-accent/80 transition-colors">Playlist</span>
  <h1 className="text-sm font-bold text-text-primary leading-none truncate max-w-[260px] group-hover:text-accent transition-colors">{selectedPlaylist.title}</h1>
  </div>
+
+ {/* Duplicate warning banner */}
+ {duplicateEntriesCount > 0 && (
+ <div className="flex items-center gap-1.5 px-2.5 py-1 rounded-lg bg-amber-500/10 border border-amber-500/30 text-amber-300 text-xs font-semibold shrink-0">
+ <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="shrink-0 text-amber-400">
+ <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z" />
+ <line x1="12" y1="9" x2="12" y2="13" />
+ <line x1="12" y1="17" x2="12.01" y2="17" />
+ </svg>
+ <span>{duplicateEntriesCount} duplicate video{duplicateEntriesCount !== 1 ? "s" : ""} detected</span>
+ </div>
+ )}
+
  {/* Purge duplicates button */}
  <button
  onClick={handlePurgeDuplicates}
@@ -480,6 +513,8 @@ export default function ChannelPage() {
  className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg border text-[11px] font-bold transition-all active:scale-95 shrink-0 ${
  purgingDuplicates
  ? "bg-orange-500/10 border-orange-500/30 text-orange-400 cursor-wait"
+ : duplicateEntriesCount > 0
+ ? "bg-amber-500/15 border-amber-500/40 text-amber-300 hover:bg-amber-500/25"
  : "bg-elevated/50 border-border-subtle text-text-secondary hover:text-orange-400 hover:border-orange-500/40 hover:bg-orange-500/10"
  } disabled:opacity-60 disabled:active:scale-100`}
  >
@@ -495,7 +530,7 @@ export default function ChannelPage() {
  <line x1="10" y1="11" x2="10" y2="17" />
  <line x1="14" y1="11" x2="14" y2="17" />
  </svg>
- Purge Duplicates
+ Purge Duplicates {duplicateEntriesCount > 0 ? `(${duplicateEntriesCount})` : ""}
  </>
  )}
  </button>
@@ -692,9 +727,9 @@ export default function ChannelPage() {
  </div>
  ) : (
  <>
- {playerVideos.map((v) => (
- <div key={v.id} data-selected={selectedVideo?.id === v.id}>
- <VideoPill video={v} selected={selectedVideo?.id === v.id} onUpdate={() => loadData(true)} viewMode="list" compact={true} onClick={() => setSelectedVideo(v)} />
+ {playerVideos.map((v, idx) => (
+ <div key={`${v.id}-${idx}`} data-selected={selectedVideo?.id === v.id}>
+ <VideoPill video={v} selected={selectedVideo?.id === v.id} onUpdate={() => loadData(true)} viewMode="list" compact={true} onClick={() => setSelectedVideo(v)} duplicateCount={selectedPlaylist ? playlistVideoCounts.get(v.id) : undefined} />
  </div>
  ))}
  <div ref={loadMoreRef} className="h-8 flex items-center justify-center shrink-0">
@@ -722,7 +757,11 @@ export default function ChannelPage() {
  </div>
  ) : (
  <div className={viewMode === "grid" ? "grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-4" : "flex flex-col gap-2"}>
- {filteredVideos.map((v) => (<div key={v.id} onClick={(e) => handleVideoClick(v, e)}><VideoPill video={v} multiSelected={selectedVideoIds.has(v.id)} onUpdate={() => loadData(true)} viewMode={viewMode} onSelectToggle={() => handleSelectToggle(v)} /></div>))}
+ {filteredVideos.map((v, idx) => (
+ <div key={`${v.id}-${idx}`} onClick={(e) => handleVideoClick(v, e)}>
+ <VideoPill video={v} multiSelected={selectedVideoIds.has(v.id)} onUpdate={() => loadData(true)} viewMode={viewMode} onSelectToggle={() => handleSelectToggle(v)} duplicateCount={playlistVideoCounts.get(v.id)} />
+ </div>
+ ))}
  </div>
  )
  ) : activeTab === "videos" ? (

--- a/frontend/src/pages/__tests__/ChannelPage.test.tsx
+++ b/frontend/src/pages/__tests__/ChannelPage.test.tsx
@@ -254,5 +254,50 @@ describe("ChannelPage YouTube Sync State", () => {
     expect(screen.getByText("Syncing: playlists (5/10)")).toBeInTheDocument();
     expect(screen.queryByText(/undefined/i)).not.toBeInTheDocument();
   });
+
+  it("shows duplicate warning banner and badges on duplicate videos in playlist view", async () => {
+    const mockPlaylists = [
+      { id: "pl-1", title: "Boss Battles", description: "", videoCount: 3, thumbnailUrl: "", publishedAt: "", privacy: "public" },
+    ];
+    const mockPlaylistVideos = [
+      { id: "v1", title: "Boss 1", description: "", publishedAt: "2026-01-01T00:00:00Z", thumbnailUrl: "", viewCount: 10, likeCount: 1, duration: "PT1M", privacy: "public", localFile: "" },
+      { id: "v2", title: "Boss 2", description: "", publishedAt: "2026-01-02T00:00:00Z", thumbnailUrl: "", viewCount: 20, likeCount: 2, duration: "PT2M", privacy: "public", localFile: "" },
+      { id: "v1", title: "Boss 1", description: "", publishedAt: "2026-01-01T00:00:00Z", thumbnailUrl: "", viewCount: 10, likeCount: 1, duration: "PT1M", privacy: "public", localFile: "" },
+    ];
+
+    vi.mocked(AppBackend.GetChannelPlaylists).mockResolvedValue(mockPlaylists as any);
+    vi.mocked(AppBackend.GetPlaylistVideos).mockResolvedValue(mockPlaylistVideos as any);
+
+    render(<ChannelPage />);
+
+    // Switch to playlists tab
+    const playlistsTab = await screen.findByRole("button", { name: "Playlists" });
+    fireEvent.click(playlistsTab);
+
+    // Open playlist
+    const playlistCard = await screen.findByText("Boss Battles");
+    fireEvent.click(playlistCard);
+
+    // Wait for playlist items to load
+    await waitFor(() => {
+      expect(screen.getByText("1 duplicate video detected")).toBeInTheDocument();
+    });
+
+    // Verify duplicate badge on cards
+    const duplicateBadges = screen.getAllByText("Duplicate (2x)");
+    expect(duplicateBadges.length).toBe(2);
+
+    // Verify purge duplicates button shows count badge
+    const purgeButton = screen.getByRole("button", { name: /Purge Duplicates \(1\)/i });
+    expect(purgeButton).toBeInTheDocument();
+
+    // Trigger purge
+    vi.mocked(AppBackend.PurgePlaylistDuplicates).mockResolvedValue(1);
+    fireEvent.click(purgeButton);
+
+    await waitFor(() => {
+      expect(AppBackend.PurgePlaylistDuplicates).toHaveBeenCalledWith("pl-1");
+    });
+  });
 });
 

--- a/tests/backend/playlist_test.go
+++ b/tests/backend/playlist_test.go
@@ -99,3 +99,54 @@ func TestUpdatePlaylistVisibility_ValidationAndAuthCheck(t *testing.T) {
 	}
 }
 
+func TestPlaylistItems_DuplicateVideoEntries(t *testing.T) {
+	app, tempDir := setupTestApp(t)
+	defer os.RemoveAll(tempDir)
+
+	dbPath := filepath.Join(tempDir, "test.db")
+	err := app.InitTestDB(dbPath)
+	if err != nil {
+		t.Fatalf("Failed to init test DB: %v", err)
+	}
+
+	db := app.GetDB()
+	// Insert test video and playlist
+	_, err = db.Exec(`
+		INSERT INTO yt_videos (id, title, description, published_at, thumbnail_url, view_count, like_count, duration, privacy)
+		VALUES 
+			('vid1', 'Video One', 'Description 1', '2026-01-01T00:00:00Z', 'https://example.com/1.jpg', 100, 10, 'PT5M', 'public'),
+			('vid2', 'Video Two', 'Description 2', '2026-01-02T00:00:00Z', 'https://example.com/2.jpg', 200, 20, 'PT10M', 'public');
+		INSERT INTO yt_playlists (id, title, description, video_count, thumbnail_url, published_at, synced_at, privacy)
+		VALUES ('PL_DUP', 'Playlist with Duplicates', 'Desc', 3, 'https://example.com/p.jpg', '2026-01-01T00:00:00Z', 1000, 'public');
+	`)
+	if err != nil {
+		t.Fatalf("Failed to insert fixtures: %v", err)
+	}
+
+	// Insert duplicate video entries: vid1 at position 0, vid2 at position 1, vid1 at position 2
+	_, err = db.Exec(`
+		INSERT INTO yt_playlist_items (playlist_id, video_id, position)
+		VALUES 
+			('PL_DUP', 'vid1', 0),
+			('PL_DUP', 'vid2', 1),
+			('PL_DUP', 'vid1', 2);
+	`)
+	if err != nil {
+		t.Fatalf("Failed to insert playlist items with duplicates: %v", err)
+	}
+
+	videos, err := app.GetPlaylistVideos("PL_DUP")
+	if err != nil {
+		t.Fatalf("GetPlaylistVideos returned error: %v", err)
+	}
+
+	if len(videos) != 3 {
+		t.Fatalf("Expected 3 playlist video entries (including duplicates), got %d", len(videos))
+	}
+
+	if videos[0].ID != "vid1" || videos[1].ID != "vid2" || videos[2].ID != "vid1" {
+		t.Errorf("Expected video order ['vid1', 'vid2', 'vid1'], got [%s, %s, %s]",
+			videos[0].ID, videos[1].ID, videos[2].ID)
+	}
+}
+


### PR DESCRIPTION
﻿Closes #34

### Summary of Changes
- **Backend**:
  - Migrated `yt_playlist_items` SQLite table to `id INTEGER PRIMARY KEY AUTOINCREMENT` with indexes on `(playlist_id, position)` and `video_id` so duplicate entries within playlists are preserved with their respective positions.
  - Updated `syncPlaylistItems` to transactionally sync all playlist items in order without dropping duplicates.
  - Added unit test `TestPlaylistItems_DuplicateVideoEntries` to verify duplicate support.
- **Frontend**:
  - Added `duplicateCount?: number` property to `VideoPill` to render a clean amber warning badge (`Duplicate (2x)`, `Duplicate (3x)`) on duplicate video cards.
  - Exposed `playlistVideos` from `useChannelData` and computed duplicate video frequencies and excess duplicate counts.
  - Displayed duplicate warning alert banner in playlist header and highlighted the `Purge Duplicates` button with an active count badge.
  - Updated item key generation in playlist view to prevent duplicate React key warnings.
  - Added comprehensive unit tests in `VideoPill.test.tsx` and `ChannelPage.test.tsx`.
