### PR TITLE
Add video monetization and issue status indicators next to view stats (fixes #37)

### DIFF
--- a/backend/database.go
+++ b/backend/database.go
@@ -47,6 +47,11 @@ func (db *DB) migrate() error {
 			duration TEXT,
 			privacy TEXT,
 			local_file TEXT,
+			game_tag TEXT,
+			episode INTEGER,
+			monetization_status TEXT DEFAULT 'monetized',
+			rejection_reason TEXT DEFAULT '',
+			status_issues TEXT DEFAULT '',
 			synced_at INTEGER
 		)`,
 		`CREATE TABLE IF NOT EXISTS yt_playlists (
@@ -113,11 +118,20 @@ func (db *DB) migrate() error {
 		)`,
 	}
 	
+	for _, q := range queries {
+		if _, err := db.conn.Exec(q); err != nil {
+			return fmt.Errorf("migration failed on query: %w", err)
+		}
+	}
+
 	// Migración manual para añadir columnas si no existen (ignorar error si ya existen)
 	db.conn.Exec("ALTER TABLE yt_playlists ADD COLUMN published_at TEXT")
 	db.conn.Exec("ALTER TABLE yt_playlists ADD COLUMN privacy TEXT")
 	db.conn.Exec("ALTER TABLE yt_videos ADD COLUMN game_tag TEXT")
 	db.conn.Exec("ALTER TABLE yt_videos ADD COLUMN episode INTEGER")
+	db.conn.Exec("ALTER TABLE yt_videos ADD COLUMN monetization_status TEXT DEFAULT 'monetized'")
+	db.conn.Exec("ALTER TABLE yt_videos ADD COLUMN rejection_reason TEXT DEFAULT ''")
+	db.conn.Exec("ALTER TABLE yt_videos ADD COLUMN status_issues TEXT DEFAULT ''")
 
 	// Migrate yt_playlist_items if legacy composite primary key exists
 	var isCompositePK bool

--- a/backend/youtube_sync.go
+++ b/backend/youtube_sync.go
@@ -13,17 +13,73 @@ import (
 )
 
 type YTVideo struct {
-	ID            string `json:"id"`
-	Title         string `json:"title"`
-	Description   string `json:"description"`
-	PublishedAt   string `json:"publishedAt"`
-	ThumbnailUrl  string `json:"thumbnailUrl"`
-	ViewCount     uint64 `json:"viewCount"`
-	LikeCount     uint64 `json:"likeCount"`
-	Duration      string `json:"duration"`
-	Privacy       string `json:"privacy"`
-	LocalFile     string `json:"localFile,omitempty"`
-	PlaylistTitle string `json:"playlistTitle,omitempty"`
+	ID                 string   `json:"id"`
+	Title              string   `json:"title"`
+	Description        string   `json:"description"`
+	PublishedAt        string   `json:"publishedAt"`
+	ThumbnailUrl       string   `json:"thumbnailUrl"`
+	ViewCount          uint64   `json:"viewCount"`
+	LikeCount          uint64   `json:"likeCount"`
+	Duration           string   `json:"duration"`
+	Privacy            string   `json:"privacy"`
+	LocalFile          string   `json:"localFile,omitempty"`
+	PlaylistTitle      string   `json:"playlistTitle,omitempty"`
+	Episode            *int     `json:"episode,omitempty"`
+	MonetizationStatus string   `json:"monetizationStatus,omitempty"`
+	RejectionReason    string   `json:"rejectionReason,omitempty"`
+	StatusIssues       []string `json:"statusIssues,omitempty"`
+}
+
+// ComputeVideoStatus determines monetization status and any specific issues
+func ComputeVideoStatus(uploadStatus, rejectionReason, ytRating string, regionBlocked []string) (string, []string) {
+	issues := make([]string, 0)
+
+	normUpload := strings.ToLower(strings.TrimSpace(uploadStatus))
+	normRejection := strings.ToLower(strings.TrimSpace(rejectionReason))
+	normRating := strings.TrimSpace(ytRating)
+
+	if normUpload == "rejected" {
+		issues = append(issues, "rejected")
+	} else if normUpload == "failed" {
+		issues = append(issues, "failed")
+	}
+
+	if normRejection != "" {
+		issues = append(issues, normRejection)
+	}
+
+	if normRating == "ytAgeRestricted" {
+		issues = append(issues, "age_restricted")
+	}
+
+	if len(regionBlocked) > 0 {
+		issues = append(issues, "region_restricted")
+	}
+
+	if normUpload == "rejected" || normUpload == "failed" || normRejection != "" {
+		return "demonetized", issues
+	}
+
+	if normRating == "ytAgeRestricted" || len(regionBlocked) > 0 {
+		return "limited", issues
+	}
+
+	return "monetized", issues
+}
+
+func parseStatusIssues(issuesStr string) []string {
+	if strings.TrimSpace(issuesStr) == "" {
+		return []string{}
+	}
+	parts := strings.Split(issuesStr, ",")
+	res := make([]string, 0, len(parts))
+	for _, p := range parts {
+		trimmed := strings.TrimSpace(p)
+		if trimmed != "" {
+			res = append(res, trimmed)
+		}
+	}
+	return res
 }
 
 type YTPlaylist struct {
@@ -440,14 +496,34 @@ func (a *App) syncVideos(svc *youtube.Service, uploadsPlaylistID string, syncTim
 					}
 				}
 
-				tx.Exec(`INSERT INTO yt_videos (id, title, description, published_at, thumbnail_url, view_count, like_count, duration, privacy, synced_at)
-					VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				ytRating := ""
+				if vid.ContentDetails != nil && vid.ContentDetails.ContentRating != nil {
+					ytRating = vid.ContentDetails.ContentRating.YtRating
+				}
+				var regionBlocked []string
+				if vid.ContentDetails != nil && vid.ContentDetails.RegionRestriction != nil {
+					regionBlocked = vid.ContentDetails.RegionRestriction.Blocked
+				}
+				uploadStatus := ""
+				rejectionReason := ""
+				if vid.Status != nil {
+					uploadStatus = vid.Status.UploadStatus
+					rejectionReason = vid.Status.RejectionReason
+				}
+				monetizationStatus, issues := ComputeVideoStatus(uploadStatus, rejectionReason, ytRating, regionBlocked)
+				issuesStr := strings.Join(issues, ",")
+
+				tx.Exec(`INSERT INTO yt_videos (id, title, description, published_at, thumbnail_url, view_count, like_count, duration, privacy, monetization_status, rejection_reason, status_issues, synced_at)
+					VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 					ON CONFLICT(id) DO UPDATE SET
 					title=excluded.title, description=excluded.description, published_at=excluded.published_at,
 					thumbnail_url=excluded.thumbnail_url, view_count=excluded.view_count, like_count=excluded.like_count,
-					duration=excluded.duration, privacy=excluded.privacy, synced_at=excluded.synced_at`,
+					duration=excluded.duration, privacy=excluded.privacy,
+					monetization_status=excluded.monetization_status, rejection_reason=excluded.rejection_reason, status_issues=excluded.status_issues,
+					synced_at=excluded.synced_at`,
 					vid.Id, vid.Snippet.Title, vid.Snippet.Description, vid.Snippet.PublishedAt, thumb,
-					vid.Statistics.ViewCount, vid.Statistics.LikeCount, vid.ContentDetails.Duration, vid.Status.PrivacyStatus, syncTime)
+					vid.Statistics.ViewCount, vid.Statistics.LikeCount, vid.ContentDetails.Duration, vid.Status.PrivacyStatus,
+					monetizationStatus, rejectionReason, issuesStr, syncTime)
 			}
 			tx.Commit()
 			a.db.mu.Unlock()
@@ -557,14 +633,35 @@ func (a *App) SyncRecentVideos(maxVideos int) error {
 					thumb = vid.Snippet.Thumbnails.Default.Url
 				}
 			}
-			tx.Exec(`INSERT INTO yt_videos (id, title, description, published_at, thumbnail_url, view_count, like_count, duration, privacy, synced_at)
-				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+
+			ytRating := ""
+			if vid.ContentDetails != nil && vid.ContentDetails.ContentRating != nil {
+				ytRating = vid.ContentDetails.ContentRating.YtRating
+			}
+			var regionBlocked []string
+			if vid.ContentDetails != nil && vid.ContentDetails.RegionRestriction != nil {
+				regionBlocked = vid.ContentDetails.RegionRestriction.Blocked
+			}
+			uploadStatus := ""
+			rejectionReason := ""
+			if vid.Status != nil {
+				uploadStatus = vid.Status.UploadStatus
+				rejectionReason = vid.Status.RejectionReason
+			}
+			monetizationStatus, issues := ComputeVideoStatus(uploadStatus, rejectionReason, ytRating, regionBlocked)
+			issuesStr := strings.Join(issues, ",")
+
+			tx.Exec(`INSERT INTO yt_videos (id, title, description, published_at, thumbnail_url, view_count, like_count, duration, privacy, monetization_status, rejection_reason, status_issues, synced_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 				ON CONFLICT(id) DO UPDATE SET
 				title=excluded.title, description=excluded.description, published_at=excluded.published_at,
 				thumbnail_url=excluded.thumbnail_url, view_count=excluded.view_count, like_count=excluded.like_count,
-				duration=excluded.duration, privacy=excluded.privacy, synced_at=excluded.synced_at`,
+				duration=excluded.duration, privacy=excluded.privacy,
+				monetization_status=excluded.monetization_status, rejection_reason=excluded.rejection_reason, status_issues=excluded.status_issues,
+				synced_at=excluded.synced_at`,
 				vid.Id, vid.Snippet.Title, vid.Snippet.Description, vid.Snippet.PublishedAt, thumb,
-				vid.Statistics.ViewCount, vid.Statistics.LikeCount, vid.ContentDetails.Duration, vid.Status.PrivacyStatus, syncTime)
+				vid.Statistics.ViewCount, vid.Statistics.LikeCount, vid.ContentDetails.Duration, vid.Status.PrivacyStatus,
+				monetizationStatus, rejectionReason, issuesStr, syncTime)
 		}
 		tx.Commit()
 		a.db.mu.Unlock()
@@ -629,7 +726,8 @@ func (a *App) GetChannelVideosPaginated(page, limit int, sortBy, search, dateFro
 	if sortBy == "title_date" || hasDateFilter {
 		query := fmt.Sprintf(`
 			SELECT v.id, COALESCE(v.title, ''), COALESCE(v.description, ''), COALESCE(v.published_at, ''), COALESCE(v.thumbnail_url, ''), COALESCE(v.view_count, 0), COALESCE(v.like_count, 0), COALESCE(v.duration, ''), COALESCE(v.privacy, ''), v.local_file,
-			       (SELECT p.title FROM yt_playlists p JOIN yt_playlist_items pi ON p.id = pi.playlist_id WHERE pi.video_id = v.id LIMIT 1) as playlist_title
+			       (SELECT p.title FROM yt_playlists p JOIN yt_playlist_items pi ON p.id = pi.playlist_id WHERE pi.video_id = v.id LIMIT 1) as playlist_title,
+			       COALESCE(v.monetization_status, 'monetized'), COALESCE(v.rejection_reason, ''), COALESCE(v.status_issues, '')
 			FROM yt_videos v
 			WHERE %s`, where)
 
@@ -644,7 +742,8 @@ func (a *App) GetChannelVideosPaginated(page, limit int, sortBy, search, dateFro
 			var v YTVideo
 			var localFile sql.NullString
 			var playlistTitle sql.NullString
-			if err := rows.Scan(&v.ID, &v.Title, &v.Description, &v.PublishedAt, &v.ThumbnailUrl, &v.ViewCount, &v.LikeCount, &v.Duration, &v.Privacy, &localFile, &playlistTitle); err != nil {
+			var issuesStr string
+			if err := rows.Scan(&v.ID, &v.Title, &v.Description, &v.PublishedAt, &v.ThumbnailUrl, &v.ViewCount, &v.LikeCount, &v.Duration, &v.Privacy, &localFile, &playlistTitle, &v.MonetizationStatus, &v.RejectionReason, &issuesStr); err != nil {
 				continue
 			}
 			if localFile.Valid {
@@ -653,6 +752,7 @@ func (a *App) GetChannelVideosPaginated(page, limit int, sortBy, search, dateFro
 			if playlistTitle.Valid {
 				v.PlaylistTitle = playlistTitle.String
 			}
+			v.StatusIssues = parseStatusIssues(issuesStr)
 
 			if hasDateFilter {
 				uploadDate := ""
@@ -737,7 +837,8 @@ func (a *App) GetChannelVideosPaginated(page, limit int, sortBy, search, dateFro
 
 	query := fmt.Sprintf(`
 		SELECT v.id, COALESCE(v.title, ''), COALESCE(v.description, ''), COALESCE(v.published_at, ''), COALESCE(v.thumbnail_url, ''), COALESCE(v.view_count, 0), COALESCE(v.like_count, 0), COALESCE(v.duration, ''), COALESCE(v.privacy, ''), v.local_file,
-		       (SELECT p.title FROM yt_playlists p JOIN yt_playlist_items pi ON p.id = pi.playlist_id WHERE pi.video_id = v.id LIMIT 1) as playlist_title
+		       (SELECT p.title FROM yt_playlists p JOIN yt_playlist_items pi ON p.id = pi.playlist_id WHERE pi.video_id = v.id LIMIT 1) as playlist_title,
+		       COALESCE(v.monetization_status, 'monetized'), COALESCE(v.rejection_reason, ''), COALESCE(v.status_issues, '')
 		FROM yt_videos v
 		WHERE %s
 		ORDER BY %s
@@ -756,7 +857,8 @@ func (a *App) GetChannelVideosPaginated(page, limit int, sortBy, search, dateFro
 		var v YTVideo
 		var localFile sql.NullString
 		var playlistTitle sql.NullString
-		if err := rows.Scan(&v.ID, &v.Title, &v.Description, &v.PublishedAt, &v.ThumbnailUrl, &v.ViewCount, &v.LikeCount, &v.Duration, &v.Privacy, &localFile, &playlistTitle); err != nil {
+		var issuesStr string
+		if err := rows.Scan(&v.ID, &v.Title, &v.Description, &v.PublishedAt, &v.ThumbnailUrl, &v.ViewCount, &v.LikeCount, &v.Duration, &v.Privacy, &localFile, &playlistTitle, &v.MonetizationStatus, &v.RejectionReason, &issuesStr); err != nil {
 			fmt.Println("Error scanning video row:", err)
 			continue
 		}
@@ -766,6 +868,7 @@ func (a *App) GetChannelVideosPaginated(page, limit int, sortBy, search, dateFro
 		if playlistTitle.Valid {
 			v.PlaylistTitle = playlistTitle.String
 		}
+		v.StatusIssues = parseStatusIssues(issuesStr)
 		videos = append(videos, v)
 	}
 
@@ -831,7 +934,8 @@ func (a *App) GetPlaylistVideos(playlistID string) ([]YTVideo, error) {
 
 	rows, err := a.db.conn.Query(`
 		SELECT v.id, COALESCE(v.title, ''), COALESCE(v.description, ''), COALESCE(v.published_at, ''), COALESCE(v.thumbnail_url, ''), 
-		       COALESCE(v.view_count, 0), COALESCE(v.like_count, 0), COALESCE(v.duration, ''), COALESCE(v.privacy, ''), v.local_file
+		       COALESCE(v.view_count, 0), COALESCE(v.like_count, 0), COALESCE(v.duration, ''), COALESCE(v.privacy, ''), v.local_file,
+		       COALESCE(v.monetization_status, 'monetized'), COALESCE(v.rejection_reason, ''), COALESCE(v.status_issues, '')
 		FROM yt_videos v
 		JOIN yt_playlist_items pi ON v.id = pi.video_id
 		WHERE pi.playlist_id = ?
@@ -845,17 +949,33 @@ func (a *App) GetPlaylistVideos(playlistID string) ([]YTVideo, error) {
 	for rows.Next() {
 		var v YTVideo
 		var localFile sql.NullString
+		var issuesStr string
 		err := rows.Scan(&v.ID, &v.Title, &v.Description, &v.PublishedAt, &v.ThumbnailUrl,
-			&v.ViewCount, &v.LikeCount, &v.Duration, &v.Privacy, &localFile)
+			&v.ViewCount, &v.LikeCount, &v.Duration, &v.Privacy, &localFile,
+			&v.MonetizationStatus, &v.RejectionReason, &issuesStr)
 		if err != nil {
 			continue
 		}
 		if localFile.Valid {
 			v.LocalFile = localFile.String
 		}
+		v.StatusIssues = parseStatusIssues(issuesStr)
 		videos = append(videos, v)
 	}
 	return videos, nil
+}
+
+// UpdateVideoMonetizationStatus manually updates the monetization and issue status for a video
+func (a *App) UpdateVideoMonetizationStatus(videoID, status, rejectionReason string, issues []string) error {
+	a.db.mu.Lock()
+	defer a.db.mu.Unlock()
+
+	issuesStr := strings.Join(issues, ",")
+	_, err := a.db.conn.Exec(`
+		UPDATE yt_videos 
+		SET monetization_status = ?, rejection_reason = ?, status_issues = ?
+		WHERE id = ?`, status, rejectionReason, issuesStr, videoID)
+	return err
 }
 
 // LinkLocalToYouTube links a local file to a YouTube ID in both SQLite and config

--- a/frontend/src/components/video/VideoPill.tsx
+++ b/frontend/src/components/video/VideoPill.tsx
@@ -23,6 +23,7 @@ import {
 	GetVideoPreview,
 	GetVideoDuration,
 } from "../../../wailsjs/go/backend/App";
+import VideoStatusBadge from "../youtube/VideoStatusBadge";
 
 interface VideoPillProps {
 	video: YTVideo | VideoFile;
@@ -349,9 +350,17 @@ export default function VideoPill({
  >
  <div className="flex items-center gap-3">
  {isYT ? (
- <span className="text-text-muted font-medium truncate">
- {formatNumber(video.viewCount)} views • {formatNumber(video.likeCount)} likes
- {publishedAt && ` • ${publishedAt}`}
+ <span className="flex items-center gap-1.5 text-text-muted font-medium truncate">
+   <VideoStatusBadge
+     monetizationStatus={(video as YTVideo).monetizationStatus}
+     rejectionReason={(video as YTVideo).rejectionReason}
+     statusIssues={(video as YTVideo).statusIssues}
+     compact={isList && compact}
+   />
+   <span>
+     {formatNumber(video.viewCount)} views • {formatNumber(video.likeCount)} likes
+     {publishedAt && ` • ${publishedAt}`}
+   </span>
  </span>
  ) : (
  <span className="flex items-center gap-1.5">

--- a/frontend/src/components/video/__tests__/VideoPill.test.tsx
+++ b/frontend/src/components/video/__tests__/VideoPill.test.tsx
@@ -1,4 +1,4 @@
-﻿import React from "react";
+import React from "react";
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
@@ -48,3 +48,29 @@ describe("VideoPill Duplicate Indicator", () => {
     expect(screen.queryByText(/Duplicate/i)).not.toBeInTheDocument();
   });
 });
+
+describe("VideoPill Monetization and Status Indicator", () => {
+  it("does not render status indicator for healthy monetized YT video with no issues", () => {
+    const monetizedVid: YTVideo = {
+      ...mockVideo,
+      monetizationStatus: "monetized",
+    };
+    render(<VideoPill video={monetizedVid} viewMode="grid" />);
+    expect(screen.queryByTestId("video-status-badge")).not.toBeInTheDocument();
+  });
+
+  it("renders demonetized / issue indicator when video has copyright issues", () => {
+    const copyrightVid: YTVideo = {
+      ...mockVideo,
+      monetizationStatus: "demonetized",
+      rejectionReason: "copyright",
+      statusIssues: ["rejected", "copyright"],
+    };
+    render(<VideoPill video={copyrightVid} viewMode="list" />);
+    const badge = screen.getByTestId("video-status-badge");
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveAttribute("title", "Demonetized • Copyright claim");
+    expect(badge.className).toContain("text-rose-500");
+  });
+});
+

--- a/frontend/src/components/youtube/VideoStatusBadge.tsx
+++ b/frontend/src/components/youtube/VideoStatusBadge.tsx
@@ -1,0 +1,98 @@
+﻿import React from "react";
+
+interface VideoStatusBadgeProps {
+  monetizationStatus?: "monetized" | "limited" | "demonetized" | "unknown" | string;
+  rejectionReason?: string;
+  statusIssues?: string[];
+  compact?: boolean;
+}
+
+const REASON_LABELS: Record<string, string> = {
+  copyright: "Copyright claim",
+  claim: "Content claim",
+  termsofuse: "Terms of use violation",
+  inappropriate: "Inappropriate content",
+  duplicate: "Duplicate video",
+  age_restricted: "Age restricted",
+  region_restricted: "Region restricted",
+  rejected: "Rejected",
+  failed: "Processing failed",
+};
+
+export default function VideoStatusBadge({
+  monetizationStatus = "monetized",
+  rejectionReason = "",
+  statusIssues = [],
+  compact = false,
+}: VideoStatusBadgeProps) {
+  let issuesList = [
+    ...(rejectionReason ? [rejectionReason] : []),
+    ...(statusIssues || []).filter((i) => i.toLowerCase() !== rejectionReason.toLowerCase()),
+  ];
+
+  if (rejectionReason && issuesList.includes("rejected")) {
+    issuesList = issuesList.filter((i) => i !== "rejected");
+  }
+
+  const uniqueIssues = Array.from(new Set(issuesList));
+  const detailedIssues = uniqueIssues
+    .map((r) => REASON_LABELS[r.toLowerCase()] || r.replace(/_/g, " "))
+    .join(" • ");
+
+  const normalizedStatus = (monetizationStatus || "monetized").toLowerCase();
+
+  let title = "";
+  let colorClass = "";
+  let iconType: "yellow" | "red" | null = null;
+
+  if (
+    normalizedStatus === "demonetized" ||
+    uniqueIssues.includes("copyright") ||
+    uniqueIssues.includes("claim") ||
+    uniqueIssues.includes("rejected") ||
+    uniqueIssues.includes("failed")
+  ) {
+    colorClass = "text-rose-500 bg-rose-500/10 border-rose-500/30";
+    iconType = "red";
+    title = detailedIssues ? `Demonetized • ${detailedIssues}` : "Demonetized";
+  } else if (
+    normalizedStatus === "limited" ||
+    uniqueIssues.includes("age_restricted") ||
+    uniqueIssues.includes("region_restricted")
+  ) {
+    colorClass = "text-amber-400 bg-amber-400/10 border-amber-400/30";
+    iconType = "yellow";
+    title = detailedIssues ? `Limited monetization • ${detailedIssues}` : "Limited monetization";
+  } else {
+    return null;
+  }
+
+  return (
+    <span
+      data-testid="video-status-badge"
+      title={title}
+      className={`inline-flex items-center justify-center rounded-full font-bold select-none border transition-colors shrink-0 ${
+        compact ? "w-3.5 h-3.5 text-[9px]" : "w-4 h-4 text-[10px]"
+      } ${colorClass}`}
+    >
+      {iconType === "red" ? (
+        <svg
+          width={compact ? "9" : "10"}
+          height={compact ? "9" : "10"}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="3"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <line x1="12" y1="1" x2="12" y2="23" />
+          <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
+          <line x1="3" y1="3" x2="21" y2="21" />
+        </svg>
+      ) : (
+        <span className="leading-none">$</span>
+      )}
+    </span>
+  );
+}

--- a/frontend/src/components/youtube/__tests__/VideoStatusBadge.test.tsx
+++ b/frontend/src/components/youtube/__tests__/VideoStatusBadge.test.tsx
@@ -1,0 +1,48 @@
+﻿import React from "react";
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import VideoStatusBadge from "../VideoStatusBadge";
+
+describe("VideoStatusBadge", () => {
+  it("does not render badge (returns null) when video has no issues and is monetized", () => {
+    render(<VideoStatusBadge monetizationStatus="monetized" />);
+    expect(screen.queryByTestId("video-status-badge")).not.toBeInTheDocument();
+  });
+
+  it("renders limited monetization badge (yellow) when limited or age restricted", () => {
+    render(<VideoStatusBadge monetizationStatus="limited" statusIssues={["age_restricted"]} />);
+    const badge = screen.getByTestId("video-status-badge");
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveAttribute("title", "Limited monetization • Age restricted");
+    expect(badge.className).toContain("text-amber-400");
+  });
+
+  it("renders demonetized / copyright badge (red) when copyright claim exists", () => {
+    render(
+      <VideoStatusBadge
+        monetizationStatus="demonetized"
+        rejectionReason="copyright"
+        statusIssues={["rejected", "copyright"]}
+      />
+    );
+    const badge = screen.getByTestId("video-status-badge");
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveAttribute("title", "Demonetized • Copyright claim");
+    expect(badge.className).toContain("text-rose-500");
+  });
+
+  it("renders custom reason in tooltip when available", () => {
+    render(
+      <VideoStatusBadge
+        monetizationStatus="demonetized"
+        rejectionReason="termsOfUse"
+        statusIssues={["termsOfUse"]}
+      />
+    );
+    const badge = screen.getByTestId("video-status-badge");
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveAttribute("title", "Demonetized • Terms of use violation");
+    expect(badge.className).toContain("text-rose-500");
+  });
+});

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -38,18 +38,21 @@ export interface Config {
 }
 
 export interface YTVideo {
- id: string;
- title: string;
- description: string;
- publishedAt: string;
- thumbnailUrl: string;
- viewCount: number;
- likeCount: number;
- duration: string;
- privacy: string;
- localFile?: string;
- playlistTitle?: string;
- episode?: number;
+  id: string;
+  title: string;
+  description: string;
+  publishedAt: string;
+  thumbnailUrl: string;
+  viewCount: number;
+  likeCount: number;
+  duration: string;
+  privacy: string;
+  localFile?: string;
+  playlistTitle?: string;
+  episode?: number;
+  monetizationStatus?: "monetized" | "limited" | "demonetized" | "unknown" | string;
+  rejectionReason?: string;
+  statusIssues?: string[];
 }
 
 export interface YTPlaylist {

--- a/tests/backend/video_status_test.go
+++ b/tests/backend/video_status_test.go
@@ -1,0 +1,195 @@
+﻿package backend_test
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"amon-hen/backend"
+)
+
+func TestComputeVideoStatus(t *testing.T) {
+	tests := []struct {
+		name               string
+		uploadStatus       string
+		rejectionReason    string
+		ytRating           string
+		regionBlocked      []string
+		expectedStatus     string
+		expectedIssues     []string
+	}{
+		{
+			name:            "Healthy monetized public video",
+			uploadStatus:    "processed",
+			rejectionReason: "",
+			ytRating:        "",
+			regionBlocked:   nil,
+			expectedStatus:  "monetized",
+			expectedIssues:  []string{},
+		},
+		{
+			name:            "Copyright claim / rejection",
+			uploadStatus:    "rejected",
+			rejectionReason: "copyright",
+			ytRating:        "",
+			regionBlocked:   nil,
+			expectedStatus:  "demonetized",
+			expectedIssues:  []string{"rejected", "copyright"},
+		},
+		{
+			name:            "Content claim rejection",
+			uploadStatus:    "processed",
+			rejectionReason: "claim",
+			ytRating:        "",
+			regionBlocked:   nil,
+			expectedStatus:  "demonetized",
+			expectedIssues:  []string{"claim"},
+		},
+		{
+			name:            "Age restricted video",
+			uploadStatus:    "processed",
+			rejectionReason: "",
+			ytRating:        "ytAgeRestricted",
+			regionBlocked:   nil,
+			expectedStatus:  "limited",
+			expectedIssues:  []string{"age_restricted"},
+		},
+		{
+			name:            "Region restricted video",
+			uploadStatus:    "processed",
+			rejectionReason: "",
+			ytRating:        "",
+			regionBlocked:   []string{"DE", "JP"},
+			expectedStatus:  "limited",
+			expectedIssues:  []string{"region_restricted"},
+		},
+		{
+			name:            "Upload failed video",
+			uploadStatus:    "failed",
+			rejectionReason: "",
+			ytRating:        "",
+			regionBlocked:   nil,
+			expectedStatus:  "demonetized",
+			expectedIssues:  []string{"failed"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			status, issues := backend.ComputeVideoStatus(tc.uploadStatus, tc.rejectionReason, tc.ytRating, tc.regionBlocked)
+			if status != tc.expectedStatus {
+				t.Errorf("Expected status %q, got %q", tc.expectedStatus, status)
+			}
+			if !reflect.DeepEqual(issues, tc.expectedIssues) {
+				t.Errorf("Expected issues %v, got %v", tc.expectedIssues, issues)
+			}
+		})
+	}
+}
+
+func TestGetChannelVideosPaginated_MonetizationFields(t *testing.T) {
+	app, tempDir := setupTestApp(t)
+	defer os.RemoveAll(tempDir)
+
+	dbPath := filepath.Join(tempDir, "test.db")
+	err := app.InitTestDB(dbPath)
+	if err != nil {
+		t.Fatalf("Failed to init test DB: %v", err)
+	}
+
+	db := app.GetDB()
+	_, err = db.Exec(`
+		INSERT INTO yt_videos (id, title, description, published_at, thumbnail_url, view_count, like_count, duration, privacy, monetization_status, rejection_reason, status_issues)
+		VALUES 
+			('v1', 'Healthy Video', 'Desc', '2026-01-01T00:00:00Z', 'https://example.com/1.jpg', 1000, 50, 'PT10M', 'public', 'monetized', '', ''),
+			('v2', 'Limited Video', 'Desc', '2026-01-02T00:00:00Z', 'https://example.com/2.jpg', 500, 20, 'PT5M', 'public', 'limited', '', 'age_restricted'),
+			('v3', 'Demonetized Video', 'Desc', '2026-01-03T00:00:00Z', 'https://example.com/3.jpg', 200, 10, 'PT8M', 'public', 'demonetized', 'copyright', 'rejected,copyright')
+	`)
+	if err != nil {
+		t.Fatalf("Failed to insert test videos: %v", err)
+	}
+
+	res, err := app.GetChannelVideosPaginated(1, 10, "recent", "", "", "")
+	if err != nil {
+		t.Fatalf("GetChannelVideosPaginated returned error: %v", err)
+	}
+
+	videos, ok := res["videos"].([]backend.YTVideo)
+	if !ok {
+		t.Fatalf("Expected videos slice, got %T", res["videos"])
+	}
+
+	if len(videos) != 3 {
+		t.Fatalf("Expected 3 videos, got %d", len(videos))
+	}
+
+	vMap := make(map[string]backend.YTVideo)
+	for _, v := range videos {
+		vMap[v.ID] = v
+	}
+
+	if vMap["v1"].MonetizationStatus != "monetized" {
+		t.Errorf("Expected v1 to be monetized, got %q", vMap["v1"].MonetizationStatus)
+	}
+	if len(vMap["v1"].StatusIssues) != 0 {
+		t.Errorf("Expected v1 to have 0 issues, got %v", vMap["v1"].StatusIssues)
+	}
+
+	if vMap["v2"].MonetizationStatus != "limited" {
+		t.Errorf("Expected v2 to be limited, got %q", vMap["v2"].MonetizationStatus)
+	}
+	if len(vMap["v2"].StatusIssues) != 1 || vMap["v2"].StatusIssues[0] != "age_restricted" {
+		t.Errorf("Expected v2 issues [age_restricted], got %v", vMap["v2"].StatusIssues)
+	}
+
+	if vMap["v3"].MonetizationStatus != "demonetized" {
+		t.Errorf("Expected v3 to be demonetized, got %q", vMap["v3"].MonetizationStatus)
+	}
+	if vMap["v3"].RejectionReason != "copyright" {
+		t.Errorf("Expected v3 rejection_reason 'copyright', got %q", vMap["v3"].RejectionReason)
+	}
+	if len(vMap["v3"].StatusIssues) != 2 {
+		t.Errorf("Expected v3 to have 2 issues, got %v", vMap["v3"].StatusIssues)
+	}
+}
+
+func TestUpdateVideoMonetizationStatus(t *testing.T) {
+	app, tempDir := setupTestApp(t)
+	defer os.RemoveAll(tempDir)
+
+	dbPath := filepath.Join(tempDir, "test.db")
+	err := app.InitTestDB(dbPath)
+	if err != nil {
+		t.Fatalf("Failed to init test DB: %v", err)
+	}
+
+	db := app.GetDB()
+	_, err = db.Exec(`
+		INSERT INTO yt_videos (id, title, description, published_at, thumbnail_url, view_count, like_count, duration, privacy, monetization_status, rejection_reason, status_issues)
+		VALUES ('v_status', 'Status Test', 'Desc', '2026-01-01T00:00:00Z', 'https://example.com/s.jpg', 100, 10, 'PT1M', 'public', 'monetized', '', '')
+	`)
+	if err != nil {
+		t.Fatalf("Failed to insert fixture: %v", err)
+	}
+
+	err = app.UpdateVideoMonetizationStatus("v_status", "demonetized", "copyright", []string{"copyright"})
+	if err != nil {
+		t.Fatalf("UpdateVideoMonetizationStatus returned error: %v", err)
+	}
+
+	res, err := app.GetChannelVideosPaginated(1, 10, "recent", "", "", "")
+	if err != nil {
+		t.Fatalf("GetChannelVideosPaginated error: %v", err)
+	}
+	videos := res["videos"].([]backend.YTVideo)
+	if len(videos) != 1 {
+		t.Fatalf("Expected 1 video, got %d", len(videos))
+	}
+	if videos[0].MonetizationStatus != "demonetized" {
+		t.Errorf("Expected status 'demonetized', got %q", videos[0].MonetizationStatus)
+	}
+	if videos[0].RejectionReason != "copyright" {
+		t.Errorf("Expected rejection reason 'copyright', got %q", videos[0].RejectionReason)
+	}
+}


### PR DESCRIPTION
﻿Closes #37

### Summary of Changes
- **Backend & SQLite**:
  - Added `monetization_status`, `rejection_reason`, and `status_issues` columns to the `yt_videos` schema and automated migrations.
  - Implemented `ComputeVideoStatus` to evaluate YouTube `uploadStatus`, `rejectionReason`, `contentRating`, and `regionRestriction` into normalized monetization and issue states (`monetized`, `limited`, `demonetized`).
  - Extended channel video pagination, playlist query endpoints, and YouTube sync routines to store and return monetization and issue flags.
- **Frontend & UI**:
  - Created `VideoStatusBadge` component positioned on the far left of the video stats row.
  - Configured badge visibility to render only when an issue is present (amber for limited/age-restricted, rose for demonetized/copyright/rejected), keeping healthy videos completely clean.
  - Ensured adherence to UI rules (no glows, no all-caps text, flat clean layout).
- **Tests**:
  - Added unit test suites covering status computation and database integration in backend (`tests/backend/video_status_test.go`).
  - Added frontend test suites verifying badge rendering and tooltip messages in `VideoStatusBadge.test.tsx` and `VideoPill.test.tsx`.
