### PR TITLE
Prevent partial text inputs from polluting profile variable suggestions (fixes #39)

### DIFF
--- a/frontend/src/components/ui/FieldInput.tsx
+++ b/frontend/src/components/ui/FieldInput.tsx
@@ -6,15 +6,16 @@ interface Props {
  value: string;
  onChange: (val: string) => void;
  onBlur?: () => void;
+ onEnter?: () => void;
  className?: string;
  placeholder?: string;
  disabled?: boolean;
 }
 
-export default function FieldInput({ fieldKey, value, onChange, onBlur, className, placeholder, disabled }: Props) {
+export default function FieldInput({ fieldKey, value, onChange, onBlur, onEnter, className, placeholder, disabled }: Props) {
  const [open, setOpen] = useState(false);
  const containerRef = useRef<HTMLDivElement>(null);
- const { getRecentValues, addRecentValue } = useRecentFieldValues();
+ const { getRecentValues, addRecentValue, removeRecentValue } = useRecentFieldValues();
  const suggestions = getRecentValues(fieldKey);
 
  // Close dropdown on click outside
@@ -30,20 +31,21 @@ export default function FieldInput({ fieldKey, value, onChange, onBlur, classNam
 
  const filtered = suggestions.filter(s => s.toLowerCase().includes(value.toLowerCase()));
 
- const handleBlur = () => {
- // Timeout to allow click on dropdown items before closing and blurring
- setTimeout(() => {
- addRecentValue(fieldKey, value);
- onBlur?.();
+ const handleSelect = (s: string) => {
+ onChange(s);
+ addRecentValue(fieldKey, s);
  setOpen(false);
- }, 150);
+ };
+
+ const handleBlur = () => {
+ onBlur?.();
  };
 
  return (
  <div className="relative flex-1" ref={containerRef}>
  <input
  type="text"
- className={className || "w-full bg-elevated border border-border-subtle rounded-sm px-3 py-2 text-sm text-text-primary outline-none transition-colors hover:border-border-medium focus:border-accent focus:bg-card focus:"}
+ className={className || "w-full bg-elevated border border-border-subtle rounded-sm px-3 py-2 text-sm text-text-primary outline-none transition-colors hover:border-border-medium focus:border-accent focus:bg-card"}
  placeholder={placeholder}
  value={value}
  onChange={e => {
@@ -54,7 +56,11 @@ export default function FieldInput({ fieldKey, value, onChange, onBlur, classNam
  onBlur={handleBlur}
  onKeyDown={e => {
  if (e.key === "Enter") {
+ if (value.trim()) {
+ addRecentValue(fieldKey, value.trim());
+ }
  setOpen(false);
+ onEnter?.();
  }
  }}
  disabled={disabled}
@@ -64,14 +70,33 @@ export default function FieldInput({ fieldKey, value, onChange, onBlur, classNam
  {filtered.map(s => (
  <div
  key={s}
- className="px-3 py-2 text-sm text-text-primary cursor-pointer hover:bg-card hover:text-accent border-b border-border-subtle last:border-b-0"
- onClick={() => {
- onChange(s);
- addRecentValue(fieldKey, s);
- setOpen(false);
+ className="group px-3 py-2 text-sm text-text-primary cursor-pointer hover:bg-card hover:text-accent border-b border-border-subtle last:border-b-0 flex items-center justify-between gap-2"
+ onMouseDown={e => {
+ e.preventDefault();
+ handleSelect(s);
+ }}
+ onClick={() => handleSelect(s)}
+ >
+ <span className="truncate flex-1">{s}</span>
+ <button
+ type="button"
+ className="p-1 text-text-muted hover:text-red-400 rounded-sm transition-colors opacity-60 hover:opacity-100 bg-transparent border-none cursor-pointer flex items-center justify-center shrink-0 z-10"
+ title={`Remove "${s}" from suggestions`}
+ aria-label={`Remove suggestion ${s}`}
+ onMouseDown={e => {
+ e.preventDefault();
+ e.stopPropagation();
+ }}
+ onClick={e => {
+ e.preventDefault();
+ e.stopPropagation();
+ removeRecentValue(fieldKey, s);
  }}
  >
- {s}
+ <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
+ <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
+ </svg>
+ </button>
  </div>
  ))}
  </div>
@@ -79,3 +104,4 @@ export default function FieldInput({ fieldKey, value, onChange, onBlur, classNam
  </div>
  );
 }
+

--- a/frontend/src/components/ui/__tests__/FieldInput.test.tsx
+++ b/frontend/src/components/ui/__tests__/FieldInput.test.tsx
@@ -1,0 +1,145 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import FieldInput from "../FieldInput";
+
+const mockAddRecentValue = vi.fn();
+const mockRemoveRecentValue = vi.fn();
+let mockSuggestions: string[] = ["Cuadrakill", "Pentakill"];
+
+vi.mock("../../../hooks/useRecentFieldValues", () => ({
+  useRecentFieldValues: () => ({
+    getRecentValues: (key: string) => mockSuggestions,
+    addRecentValue: mockAddRecentValue,
+    removeRecentValue: mockRemoveRecentValue,
+  }),
+}));
+
+describe("FieldInput", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSuggestions = ["Cuadrakill", "Pentakill"];
+  });
+
+  it("renders with placeholder and value", () => {
+    render(
+      <FieldInput
+        fieldKey="event"
+        value="Highlight 1"
+        onChange={vi.fn()}
+        placeholder="Enter event..."
+      />
+    );
+
+    const input = screen.getByPlaceholderText("Enter event...");
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveValue("Highlight 1");
+  });
+
+  it("shows suggestions matching the typed text", () => {
+    render(
+      <FieldInput
+        fieldKey="event"
+        value="Cuad"
+        onChange={vi.fn()}
+        placeholder="Enter event..."
+      />
+    );
+
+    const input = screen.getByPlaceholderText("Enter event...");
+    fireEvent.focus(input);
+
+    expect(screen.getByText("Cuadrakill")).toBeInTheDocument();
+    expect(screen.queryByText("Pentakill")).not.toBeInTheDocument();
+  });
+
+  it("does not save partial typed input to recent values when selecting a suggestion", () => {
+    const onChange = vi.fn();
+    render(
+      <FieldInput
+        fieldKey="event"
+        value="Cuad"
+        onChange={onChange}
+        placeholder="Enter event..."
+      />
+    );
+
+    const input = screen.getByPlaceholderText("Enter event...");
+    fireEvent.focus(input);
+
+    const suggestionItem = screen.getByText("Cuadrakill");
+    fireEvent.mouseDown(suggestionItem);
+    fireEvent.click(suggestionItem);
+
+    // Should call onChange with selected suggestion
+    expect(onChange).toHaveBeenCalledWith("Cuadrakill");
+    // Should save selected suggestion, NOT the partial text "Cuad"
+    expect(mockAddRecentValue).toHaveBeenCalledWith("event", "Cuadrakill");
+    expect(mockAddRecentValue).not.toHaveBeenCalledWith("event", "Cuad");
+  });
+
+  it("does not save partial typed input to recent values on blur", () => {
+    const onBlur = vi.fn();
+    render(
+      <FieldInput
+        fieldKey="event"
+        value="Cuad"
+        onChange={vi.fn()}
+        onBlur={onBlur}
+        placeholder="Enter event..."
+      />
+    );
+
+    const input = screen.getByPlaceholderText("Enter event...");
+    fireEvent.focus(input);
+    fireEvent.blur(input);
+
+    expect(onBlur).toHaveBeenCalled();
+    expect(mockAddRecentValue).not.toHaveBeenCalledWith("event", "Cuad");
+  });
+
+  it("saves confirmed value and triggers onEnter when Enter is pressed", () => {
+    const onEnter = vi.fn();
+    render(
+      <FieldInput
+        fieldKey="event"
+        value="Triple Kill"
+        onChange={vi.fn()}
+        onEnter={onEnter}
+        placeholder="Enter event..."
+      />
+    );
+
+    const input = screen.getByPlaceholderText("Enter event...");
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+    expect(mockAddRecentValue).toHaveBeenCalledWith("event", "Triple Kill");
+    expect(onEnter).toHaveBeenCalled();
+  });
+
+  it("allows removing an existing suggestion from the dropdown without selecting it", () => {
+    const onChange = vi.fn();
+    render(
+      <FieldInput
+        fieldKey="event"
+        value=""
+        onChange={onChange}
+        placeholder="Enter event..."
+      />
+    );
+
+    const input = screen.getByPlaceholderText("Enter event...");
+    fireEvent.focus(input);
+
+    const removeBtns = screen.getAllByRole("button", { name: /remove suggestion/i });
+    expect(removeBtns.length).toBe(2);
+
+    fireEvent.mouseDown(removeBtns[0]);
+    fireEvent.click(removeBtns[0]);
+
+    expect(mockRemoveRecentValue).toHaveBeenCalledWith("event", "Cuadrakill");
+    expect(onChange).not.toHaveBeenCalled();
+    expect(mockAddRecentValue).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/video/InlinePlayer.tsx
+++ b/frontend/src/components/video/InlinePlayer.tsx
@@ -446,6 +446,12 @@ export default function InlinePlayer({ video, streamPort, selectedPaths = [], on
  }
  
  if (tagInput) addRecentTag(tagInput);
+ if (eventInput) addRecentValue("event", eventInput);
+ if (customVarsInput) {
+ Object.entries(customVarsInput).forEach(([k, v]) => {
+ if (v) addRecentValue(k, v);
+ });
+ }
 
  // Reload config just in case to sync tagPlaylists
  const cfg = await LoadConfig();
@@ -505,6 +511,12 @@ export default function InlinePlayer({ video, streamPort, selectedPaths = [], on
 
  const handleUploadNow = async () => {
  if (tagInput) addRecentTag(tagInput);
+ if (eventInput) addRecentValue("event", eventInput);
+ if (customVarsInput) {
+ Object.entries(customVarsInput).forEach(([k, v]) => {
+ if (v) addRecentValue(k, v);
+ });
+ }
  setUploading(true);
  
  // Save metadata to local database first
@@ -532,6 +544,12 @@ export default function InlinePlayer({ video, streamPort, selectedPaths = [], on
 
  const handleAddToQueue = async () => {
  if (tagInput) addRecentTag(tagInput);
+ if (eventInput) addRecentValue("event", eventInput);
+ if (customVarsInput) {
+ Object.entries(customVarsInput).forEach(([k, v]) => {
+ if (v) addRecentValue(k, v);
+ });
+ }
  
  // Save metadata to local database first
  await SaveVideoMetadata(video.path, tagInput, ytTitle, description, privacy, playlistId, episodeInput !== "" ? Number(episodeInput) : (video.episode || 0), eventInput, gameModeInput, customVarsInput).catch(console.error);
@@ -725,6 +743,7 @@ export default function InlinePlayer({ video, streamPort, selectedPaths = [], on
  className="w-full bg-elevated border border-border-subtle rounded-sm px-3 py-2 text-sm text-text-primary outline-none transition-colors hover:border-border-medium focus:border-accent focus:bg-card focus:"
  value={eventInput}
  onChange={handleEventChange}
+ onEnter={handleSaveInfo}
  placeholder="Highlight..."
  />
  </div>
@@ -764,6 +783,7 @@ export default function InlinePlayer({ video, streamPort, selectedPaths = [], on
  className="w-full bg-elevated border border-border-subtle rounded-sm px-3 py-2 text-sm text-text-primary outline-none transition-colors hover:border-border-medium focus:border-accent focus:bg-card focus:"
  value={customVarsInput[cv] || ""}
  onChange={val => handleCustomVarChange(cv, val)}
+ onEnter={handleSaveInfo}
  placeholder={`${cv.charAt(0).toUpperCase() + cv.slice(1)}...`}
  />
  </div>
@@ -975,6 +995,7 @@ export default function InlinePlayer({ video, streamPort, selectedPaths = [], on
  className="w-full bg-elevated border border-border-subtle rounded-sm px-3 py-2 text-sm text-text-primary outline-none transition-colors hover:border-border-medium focus:border-accent focus:bg-card focus:"
  value={eventInput}
  onChange={handleEventChange}
+ onEnter={handleSaveInfo}
  placeholder="Highlight..."
  />
  </div>
@@ -1014,6 +1035,7 @@ export default function InlinePlayer({ video, streamPort, selectedPaths = [], on
  className="w-full bg-elevated border border-border-subtle rounded-sm px-3 py-2 text-sm text-text-primary outline-none transition-colors hover:border-border-medium focus:border-accent focus:bg-card focus:"
  value={customVarsInput[cv] || ""}
  onChange={val => handleCustomVarChange(cv, val)}
+ onEnter={handleSaveInfo}
  placeholder={`${cv.charAt(0).toUpperCase() + cv.slice(1)}...`}
  />
  </div>

--- a/frontend/src/hooks/__tests__/useRecentFieldValues.test.ts
+++ b/frontend/src/hooks/__tests__/useRecentFieldValues.test.ts
@@ -1,0 +1,88 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useRecentFieldValues } from "../useRecentFieldValues";
+import * as appBackend from "../../../wailsjs/go/backend/App";
+
+let mockConfigState: { recent_field_values: Record<string, string[]> } = {
+  recent_field_values: {
+    event: ["Quadra Kill", "Ace"],
+  },
+};
+
+vi.mock("../../../wailsjs/go/backend/App", () => ({
+  LoadConfig: vi.fn(() => Promise.resolve(mockConfigState)),
+  SaveRecentFieldValues: vi.fn((newValues) => {
+    mockConfigState.recent_field_values = newValues;
+    return Promise.resolve();
+  }),
+}));
+
+describe("useRecentFieldValues", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockConfigState = {
+      recent_field_values: {
+        event: ["Quadra Kill", "Ace"],
+      },
+    };
+  });
+
+  it("loads initial values from backend config", async () => {
+    const { result } = renderHook(() => useRecentFieldValues());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.getRecentValues("event")).toEqual(["Quadra Kill", "Ace"]);
+    expect(result.current.getRecentValues("nonexistent")).toEqual([]);
+  });
+
+  it("adds a recent value and puts it at the front without duplicates", async () => {
+    const { result } = renderHook(() => useRecentFieldValues());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      result.current.addRecentValue("event", "Pentakill");
+      await Promise.resolve();
+    });
+
+    expect(result.current.getRecentValues("event")).toEqual(["Pentakill", "Quadra Kill", "Ace"]);
+    expect(appBackend.SaveRecentFieldValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: ["Pentakill", "Quadra Kill", "Ace"],
+      })
+    );
+
+    // Adding existing item reorders it to front
+    await act(async () => {
+      result.current.addRecentValue("event", "Ace");
+      await Promise.resolve();
+    });
+
+    expect(result.current.getRecentValues("event")).toEqual(["Ace", "Pentakill", "Quadra Kill"]);
+  });
+
+  it("removes a recent value from the specified fieldKey", async () => {
+    const { result } = renderHook(() => useRecentFieldValues());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      result.current.removeRecentValue("event", "Quadra Kill");
+      await Promise.resolve();
+    });
+
+    expect(result.current.getRecentValues("event")).toEqual(["Ace"]);
+    expect(appBackend.SaveRecentFieldValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: ["Ace"],
+      })
+    );
+  });
+});

--- a/frontend/src/hooks/useRecentFieldValues.ts
+++ b/frontend/src/hooks/useRecentFieldValues.ts
@@ -49,9 +49,26 @@ export function useRecentFieldValues(maxItems = 10) {
  });
  }, [maxItems]);
 
+ const removeRecentValue = useCallback((fieldKey: string, valToRemove: string) => {
+ setRecentValues(prev => {
+ const current = prev[fieldKey] || [];
+ const updated = current.filter(t => t !== valToRemove);
+ const newCache = { ...prev, [fieldKey]: updated };
+
+ // Save to backend asynchronously
+ SaveRecentFieldValues(newCache).catch(e => {
+ console.error("Failed to remove recent field value from backend", e);
+ });
+
+ window.dispatchEvent(new StorageEvent('storage', { key: STORAGE_KEY }));
+
+ return newCache;
+ });
+ }, []);
+
  const getRecentValues = useCallback((fieldKey: string) => {
  return recentValues[fieldKey] || [];
  }, [recentValues]);
 
- return { getRecentValues, addRecentValue };
+ return { getRecentValues, addRecentValue, removeRecentValue };
 }


### PR DESCRIPTION
﻿Closes #39

### Summary of Changes
- Removed timer-based blur auto-saving of uncommitted typed text in `FieldInput`.
- Implemented clean suggestion selection using `onMouseDown` to prevent blur race conditions.
- Added `removeRecentValue` capability to `useRecentFieldValues` and added a delete button (`×`) on suggestion items with isolated event handling.
- Persisted confirmed profile variables on metadata save, upload, and queue actions in `InlinePlayer`.
- Added comprehensive unit test suites covering `FieldInput` and `useRecentFieldValues`.
