### PR TITLE
Add duplicate video warning indicator to playlist cards (fixes #42)

### DIFF
--- a/backend/youtube_sync.go
+++ b/backend/youtube_sync.go
@@ -83,13 +83,14 @@ func parseStatusIssues(issuesStr string) []string {
 }
 
 type YTPlaylist struct {
-	ID           string `json:"id"`
-	Title        string `json:"title"`
-	Description  string `json:"description"`
-	VideoCount   int64  `json:"videoCount"`
-	ThumbnailUrl string `json:"thumbnailUrl"`
-	PublishedAt  string `json:"publishedAt"`
-	Privacy      string `json:"privacy"`
+	ID             string `json:"id"`
+	Title          string `json:"title"`
+	Description    string `json:"description"`
+	VideoCount     int64  `json:"videoCount"`
+	ThumbnailUrl   string `json:"thumbnailUrl"`
+	PublishedAt    string `json:"publishedAt"`
+	Privacy        string `json:"privacy"`
+	DuplicateCount int64  `json:"duplicateCount"`
 }
 
 // SyncChannelData downloads all videos and playlists from the channel and saves them to SQLite.
@@ -908,7 +909,19 @@ func (a *App) GetChannelPlaylists(sortBy string) ([]YTPlaylist, error) {
 	}
 
 	rows, err := a.db.conn.Query(fmt.Sprintf(`
-		SELECT p.id, p.title, p.description, p.video_count, p.thumbnail_url, p.published_at, COALESCE(p.privacy, 'public')
+		SELECT 
+			p.id, 
+			p.title, 
+			p.description, 
+			p.video_count, 
+			p.thumbnail_url, 
+			p.published_at, 
+			COALESCE(p.privacy, 'public'),
+			COALESCE((
+				SELECT COUNT(*) - COUNT(DISTINCT pi.video_id)
+				FROM yt_playlist_items pi
+				WHERE pi.playlist_id = p.id
+			), 0) AS duplicate_count
 		FROM yt_playlists p
 		ORDER BY %s`, orderBy))
 	if err != nil {
@@ -919,7 +932,7 @@ func (a *App) GetChannelPlaylists(sortBy string) ([]YTPlaylist, error) {
 	var playlists []YTPlaylist
 	for rows.Next() {
 		var p YTPlaylist
-		if err := rows.Scan(&p.ID, &p.Title, &p.Description, &p.VideoCount, &p.ThumbnailUrl, &p.PublishedAt, &p.Privacy); err != nil {
+		if err := rows.Scan(&p.ID, &p.Title, &p.Description, &p.VideoCount, &p.ThumbnailUrl, &p.PublishedAt, &p.Privacy, &p.DuplicateCount); err != nil {
 			continue
 		}
 		playlists = append(playlists, p)

--- a/backend/youtube_sync_test.go
+++ b/backend/youtube_sync_test.go
@@ -1,0 +1,103 @@
+package backend
+
+import (
+	"database/sql"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func setupTestDB(t *testing.T) *App {
+	t.Helper()
+	conn, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open in-memory sqlite: %v", err)
+	}
+
+	app := &App{
+		db: &DB{conn: conn},
+	}
+
+	if err := app.db.migrate(); err != nil {
+		t.Fatalf("failed to run migrations: %v", err)
+	}
+
+	return app
+}
+
+func TestGetChannelPlaylists_DuplicateCount(t *testing.T) {
+	app := setupTestDB(t)
+	defer app.db.conn.Close()
+
+	// Insert playlists: pl1 has duplicates, pl2 has no duplicates, pl3 is empty
+	_, err := app.db.conn.Exec(`
+		INSERT INTO yt_playlists (id, title, description, video_count, thumbnail_url, published_at, privacy)
+		VALUES 
+			('pl-1', 'Playlist With Dups', 'Desc 1', 5, '', '2026-01-02T00:00:00Z', 'public'),
+			('pl-2', 'Clean Playlist', 'Desc 2', 3, '', '2026-01-01T00:00:00Z', 'unlisted'),
+			('pl-3', 'Empty Playlist', 'Desc 3', 0, '', '2025-12-31T00:00:00Z', 'private');
+	`)
+	if err != nil {
+		t.Fatalf("failed to insert playlists: %v", err)
+	}
+
+	// Insert playlist items:
+	// pl-1 has: vid1, vid2, vid1, vid3, vid1 -> 5 items total, 3 distinct videos (vid1 appears 3 times -> 2 duplicates)
+	// pl-2 has: vidA, vidB, vidC -> 3 items total, 3 distinct videos (0 duplicates)
+	_, err = app.db.conn.Exec(`
+		INSERT INTO yt_playlist_items (playlist_id, video_id, position)
+		VALUES 
+			('pl-1', 'vid1', 0),
+			('pl-1', 'vid2', 1),
+			('pl-1', 'vid1', 2),
+			('pl-1', 'vid3', 3),
+			('pl-1', 'vid1', 4),
+			('pl-2', 'vidA', 0),
+			('pl-2', 'vidB', 1),
+			('pl-2', 'vidC', 2);
+	`)
+	if err != nil {
+		t.Fatalf("failed to insert playlist items: %v", err)
+	}
+
+	playlists, err := app.GetChannelPlaylists("recent")
+	if err != nil {
+		t.Fatalf("GetChannelPlaylists failed: %v", err)
+	}
+
+	if len(playlists) != 3 {
+		t.Fatalf("expected 3 playlists, got %d", len(playlists))
+	}
+
+	playlistMap := make(map[string]YTPlaylist)
+	for _, p := range playlists {
+		playlistMap[p.ID] = p
+	}
+
+	// Verify pl-1 has DuplicateCount == 2
+	p1, ok := playlistMap["pl-1"]
+	if !ok {
+		t.Fatalf("pl-1 not found in result")
+	}
+	if p1.DuplicateCount != 2 {
+		t.Errorf("pl-1 DuplicateCount expected 2, got %d", p1.DuplicateCount)
+	}
+
+	// Verify pl-2 has DuplicateCount == 0
+	p2, ok := playlistMap["pl-2"]
+	if !ok {
+		t.Fatalf("pl-2 not found in result")
+	}
+	if p2.DuplicateCount != 0 {
+		t.Errorf("pl-2 DuplicateCount expected 0, got %d", p2.DuplicateCount)
+	}
+
+	// Verify pl-3 has DuplicateCount == 0
+	p3, ok := playlistMap["pl-3"]
+	if !ok {
+		t.Fatalf("pl-3 not found in result")
+	}
+	if p3.DuplicateCount != 0 {
+		t.Errorf("pl-3 DuplicateCount expected 0, got %d", p3.DuplicateCount)
+	}
+}

--- a/frontend/src/components/youtube/PlaylistCard.tsx
+++ b/frontend/src/components/youtube/PlaylistCard.tsx
@@ -278,11 +278,25 @@ export default function PlaylistCard({
             {playlist.title}
           </h3>
 
-          <div className="flex items-center">
+          <div className="flex items-center gap-1.5 flex-wrap">
             <span className={`inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md text-[10px] font-semibold border ${badge.className}`}>
               {badge.icon}
               <span>{badge.label}</span>
             </span>
+
+            {playlist.duplicateCount !== undefined && playlist.duplicateCount > 0 && (
+              <span
+                data-testid="duplicate-badge"
+                title={`${playlist.duplicateCount} duplicate video${playlist.duplicateCount !== 1 ? "s" : ""} detected in playlist`}
+                className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md text-[10px] font-semibold bg-amber-500/10 text-amber-400 border border-amber-500/25"
+              >
+                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                  <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                </svg>
+                <span>{playlist.duplicateCount} duplicate{playlist.duplicateCount !== 1 ? "s" : ""}</span>
+              </span>
+            )}
           </div>
         </div>
 

--- a/frontend/src/components/youtube/__tests__/PlaylistCard.test.tsx
+++ b/frontend/src/components/youtube/__tests__/PlaylistCard.test.tsx
@@ -122,4 +122,49 @@ describe("PlaylistCard", () => {
       expect(onDeleted).toHaveBeenCalled();
     });
   });
+
+  it("renders duplicate warning badge when duplicateCount > 0 in grid view", () => {
+    const playlistWithDups: YTPlaylist = {
+      ...mockPlaylist,
+      duplicateCount: 1,
+    };
+
+    render(<PlaylistCard playlist={playlistWithDups} viewMode="grid" />);
+
+    const badge = screen.getByTestId("duplicate-badge");
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent("1 duplicate");
+
+    const header = screen.getByTestId("playlist-card-header");
+    expect(header).toContainElement(badge);
+  });
+
+  it("renders duplicate warning badge with correct pluralization in list view", () => {
+    const playlistWithMultipleDups: YTPlaylist = {
+      ...mockPlaylist,
+      duplicateCount: 3,
+    };
+
+    render(<PlaylistCard playlist={playlistWithMultipleDups} viewMode="list" />);
+
+    const badge = screen.getByTestId("duplicate-badge");
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent("3 duplicates");
+
+    const header = screen.getByTestId("playlist-card-header");
+    expect(header).toContainElement(badge);
+  });
+
+  it("does not render duplicate badge when duplicateCount is 0 or undefined", () => {
+    const { rerender } = render(<PlaylistCard playlist={mockPlaylist} viewMode="grid" />);
+    expect(screen.queryByTestId("duplicate-badge")).not.toBeInTheDocument();
+
+    const playlistZeroDups: YTPlaylist = {
+      ...mockPlaylist,
+      duplicateCount: 0,
+    };
+    rerender(<PlaylistCard playlist={playlistZeroDups} viewMode="grid" />);
+    expect(screen.queryByTestId("duplicate-badge")).not.toBeInTheDocument();
+  });
 });
+

--- a/frontend/src/pages/__tests__/ChannelPage.test.tsx
+++ b/frontend/src/pages/__tests__/ChannelPage.test.tsx
@@ -299,5 +299,30 @@ describe("ChannelPage YouTube Sync State", () => {
       expect(AppBackend.PurgePlaylistDuplicates).toHaveBeenCalledWith("pl-1");
     });
   });
+
+  it("shows duplicate badge on playlist cards in playlist grid overview when duplicateCount > 0", async () => {
+    const mockPlaylists = [
+      { id: "pl-1", title: "Boss Battles", description: "", videoCount: 5, thumbnailUrl: "", publishedAt: "", privacy: "public", duplicateCount: 2 },
+      { id: "pl-2", title: "Clean List", description: "", videoCount: 3, thumbnailUrl: "", publishedAt: "", privacy: "public", duplicateCount: 0 },
+    ];
+
+    vi.mocked(AppBackend.GetChannelPlaylists).mockResolvedValue(mockPlaylists as any);
+
+    render(<ChannelPage />);
+
+    // Switch to playlists tab
+    const playlistsTab = await screen.findByRole("button", { name: "Playlists" });
+    fireEvent.click(playlistsTab);
+
+    // Wait for playlists to render
+    await screen.findByText("Boss Battles");
+    await screen.findByText("Clean List");
+
+    // Check duplicate badge is rendered for pl-1
+    const dupBadge = screen.getByTestId("duplicate-badge");
+    expect(dupBadge).toBeInTheDocument();
+    expect(dupBadge).toHaveTextContent("2 duplicates");
+  });
 });
+
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -63,6 +63,7 @@ export interface YTPlaylist {
  thumbnailUrl: string;
  publishedAt: string;
  privacy?: string;
+ duplicateCount?: number;
 }
 
 export interface VideoGroup {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -425,6 +425,7 @@ export namespace backend {
 	    thumbnailUrl: string;
 	    publishedAt: string;
 	    privacy: string;
+	    duplicateCount: number;
 	
 	    static createFrom(source: any = {}) {
 	        return new YTPlaylist(source);
@@ -439,6 +440,7 @@ export namespace backend {
 	        this.thumbnailUrl = source["thumbnailUrl"];
 	        this.publishedAt = source["publishedAt"];
 	        this.privacy = source["privacy"];
+	        this.duplicateCount = source["duplicateCount"];
 	    }
 	}
 	export class YTVideo {


### PR DESCRIPTION
﻿Closes #42

### Summary of Changes
- **Backend Duplicate Detection**: Extended `YTPlaylist` model with `DuplicateCount` and updated `GetChannelPlaylists` query to compute duplicate items in each playlist on-the-fly using indexed `yt_playlist_items` subqueries.
- **Visual Warning Badge**: Added duplicate warning badge to `PlaylistCard` in the badge header row for both grid and list views when `duplicateCount > 0` with proper pluralization.
- **Automated Testing**: Added backend unit tests (`youtube_sync_test.go`) and frontend unit tests (`PlaylistCard.test.tsx`, `ChannelPage.test.tsx`) covering duplicate count calculations, badge display, and pluralization.
