### PR TITLE
Highlight unfilled placeholder variables in video titles (fixes #46)

### DIFF
--- a/frontend/src/components/video/VideoPill.tsx
+++ b/frontend/src/components/video/VideoPill.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect, useRef } from "react";
 import { YTVideo, VideoFile, GameProfile } from "../../types";
 import {
- formatSize,
- formatDuration,
- generateYouTubeTitle,
+  formatSize,
+  formatDuration,
+  generateYouTubeTitle,
+  getVideoTitleSegments,
 } from "../../utils/videoUtils";
 import { getTagColor } from "../../utils/tagColors";
 import { useInView } from "../../hooks/useInView";
@@ -81,11 +82,7 @@ export default function VideoPill({
 
 	// Data normalization
 	const activeProfile = isLocal ? gameProfiles[(video as VideoFile).game || ""] : undefined;
-	const title = isYT
-		? video.title
-		: (activeProfile?.type === "multiplayer")
-		? generateYouTubeTitle(video.name, video.game, video.episode, activeProfile, video.event, video.gameMode, (video as VideoFile).customVars, (video as VideoFile).modTime)
-		: video.youtubeTitle || generateYouTubeTitle(video.name, video.game, video.episode, activeProfile, video.event, video.gameMode, (video as VideoFile).customVars, (video as VideoFile).modTime);
+	const { fullTitle: title, segments: titleSegments } = getVideoTitleSegments(video, activeProfile);
 	const subtitle = isLocal ? video.name : "";
 	const thumbnail = isYT ? video.thumbnailUrl : thumb;
 	const publishedAt = isYT
@@ -326,17 +323,35 @@ export default function VideoPill({
  className={`font-semibold text-text-primary line-clamp-2 leading-tight break-words ${isList ? "text-xs" : "text-[13px]"}`}
  title={title}
  >
- {/* Colorize game-name prefix with its deterministic per-tag color */}
- {isLocal && (video as VideoFile).game && (video as VideoFile).game!.length > 0 && title.startsWith((video as VideoFile).game!) ? (
- <>
- <span style={{ color: getTagColor((video as VideoFile).game!) }} className="font-bold ">
- {(video as VideoFile).game}
- </span>
- <span className="opacity-90">{title.slice((video as VideoFile).game!.length)}</span>
- </>
- ) : (
- title
- )}
+ 					{titleSegments.map((segment, idx) => {
+						if (segment.isGameTag) {
+							return (
+								<span
+									key={idx}
+									style={{ color: getTagColor(segment.text) }}
+									className="font-bold"
+								>
+									{segment.text}
+								</span>
+							);
+						}
+						if (segment.isPlaceholder) {
+							return (
+								<span
+									key={idx}
+									className="text-amber-400 font-semibold bg-amber-400/10 px-1 py-0.5 rounded border border-dashed border-amber-400/30 text-[11px] inline-block my-[-2px]"
+									title={`Unfilled variable: ${segment.varName || segment.text}`}
+								>
+									{segment.text}
+								</span>
+							);
+						}
+						return (
+							<span key={idx} className="opacity-90">
+								{segment.text}
+							</span>
+						);
+					})}
  </h3>
  {isList && publishedAt && (
  <span className="text-[10px] text-text-muted font-medium mt-0.5">

--- a/frontend/src/components/video/VideoPill.tsx
+++ b/frontend/src/components/video/VideoPill.tsx
@@ -319,11 +319,11 @@ export default function VideoPill({
  className={`flex flex-col flex-1 min-w-0 ${isList ? "px-3 py-2 justify-between" : "p-3 pb-2.5 gap-1.5"}`}
  >
  <div className="flex flex-col gap-0.5">
- <h3
- className={`font-semibold text-text-primary line-clamp-2 leading-tight break-words ${isList ? "text-xs" : "text-[13px]"}`}
- title={title}
- >
- 					{titleSegments.map((segment, idx) => {
+ 				<h3
+					className={`font-semibold text-text-primary line-clamp-2 leading-snug break-words ${isList ? "text-xs" : "text-[13px]"}`}
+					title={title}
+				>
+					{titleSegments.map((segment, idx) => {
 						if (segment.isGameTag) {
 							return (
 								<span
@@ -339,7 +339,7 @@ export default function VideoPill({
 							return (
 								<span
 									key={idx}
-									className="text-amber-400 font-semibold bg-amber-400/10 px-1 py-0.5 rounded border border-dashed border-amber-400/30 text-[11px] inline-block my-[-2px]"
+									className="text-amber-400 font-semibold bg-amber-500/15 px-1 py-0.5 rounded-sm text-[11px]"
 									title={`Unfilled variable: ${segment.varName || segment.text}`}
 								>
 									{segment.text}
@@ -352,17 +352,17 @@ export default function VideoPill({
 							</span>
 						);
 					})}
- </h3>
- {isList && publishedAt && (
- <span className="text-[10px] text-text-muted font-medium mt-0.5">
- {publishedAt}
- </span>
- )}
- </div>
+				</h3>
+				{isList && publishedAt && (
+					<span className="text-[10px] text-text-muted font-medium mt-0.5">
+						{publishedAt}
+					</span>
+				)}
+			</div>
 
- <div
- className={`flex items-center justify-between text-text-secondary ${isList ? "text-[10px]" : "text-[11px] mt-auto pt-1"}`}
- >
+			<div
+				className={`flex items-center justify-between text-text-secondary ${isList ? "text-[10px]" : "text-[11px] mt-auto pt-2"}`}
+			>
  <div className="flex items-center gap-3">
  {isYT ? (
  <span className="flex items-center gap-1.5 text-text-muted font-medium truncate">

--- a/frontend/src/components/video/__tests__/VideoPill.test.tsx
+++ b/frontend/src/components/video/__tests__/VideoPill.test.tsx
@@ -74,3 +74,91 @@ describe("VideoPill Monetization and Status Indicator", () => {
   });
 });
 
+describe("VideoPill Title Placeholder Highlighting", () => {
+  const localVideo = {
+    name: "2026-08-26 14-30-00.mp4",
+    path: "/videos/2026-08-26 14-30-00.mp4",
+    size: 104857600,
+    modTime: 1787754600000,
+    folder: "/videos",
+    game: "Overwatch 2",
+  };
+
+  const gameProfiles = {
+    "Overwatch 2": {
+      type: "multiplayer",
+      titleTemplate: "{game} - {event} - {gamemode} - {date}",
+      modes: ["Quick Play", "Competitive"],
+    },
+  };
+
+  it("highlights unfilled 'Title' and 'Mode' placeholders with amber badge style", () => {
+    const unfilledVideo = {
+      ...localVideo,
+      event: "",
+      gameMode: "",
+    };
+
+    render(
+      <VideoPill
+        video={unfilledVideo}
+        gameProfiles={gameProfiles}
+        viewMode="grid"
+      />
+    );
+
+    const titlePlaceholder = screen.getByText("Title");
+    const modePlaceholder = screen.getByText("Mode");
+
+    expect(titlePlaceholder).toBeInTheDocument();
+    expect(titlePlaceholder.className).toContain("text-amber-400");
+    expect(modePlaceholder).toBeInTheDocument();
+    expect(modePlaceholder.className).toContain("text-amber-400");
+  });
+
+  it("highlights only unfilled placeholders when some fields are filled", () => {
+    const partiallyFilledVideo = {
+      ...localVideo,
+      event: "Grand Finals",
+      gameMode: "",
+    };
+
+    render(
+      <VideoPill
+        video={partiallyFilledVideo}
+        gameProfiles={gameProfiles}
+        viewMode="list"
+      />
+    );
+
+    const eventText = screen.getByText("Grand Finals");
+    const modePlaceholder = screen.getByText("Mode");
+
+    expect(eventText).toBeInTheDocument();
+    expect(eventText.className).not.toContain("text-amber-400");
+    expect(modePlaceholder).toBeInTheDocument();
+    expect(modePlaceholder.className).toContain("text-amber-400");
+  });
+
+  it("does not highlight when all variables are filled", () => {
+    const filledVideo = {
+      ...localVideo,
+      event: "Grand Finals",
+      gameMode: "Competitive",
+    };
+
+    render(
+      <VideoPill
+        video={filledVideo}
+        gameProfiles={gameProfiles}
+        viewMode="grid"
+      />
+    );
+
+    expect(screen.getByText("Grand Finals")).toBeInTheDocument();
+    expect(screen.getByText("Competitive")).toBeInTheDocument();
+    expect(screen.queryByText("Title")).not.toBeInTheDocument();
+    expect(screen.queryByText("Mode")).not.toBeInTheDocument();
+  });
+});
+

--- a/frontend/src/components/youtube/UploadDialog.tsx
+++ b/frontend/src/components/youtube/UploadDialog.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { VideoFile, YTPlaylist, GameProfile } from "../../types";
-import { generateYouTubeTitle } from "../../utils/videoUtils";
+import { generateYouTubeTitle, hasUnfilledPlaceholders } from "../../utils/videoUtils";
 import { useAppStore } from "../../store/useAppStore";
 import { PlaylistPrivacy } from "../../types";
 import { QueueItem } from "./UploadQueue";
@@ -186,6 +186,16 @@ export default function UploadDialog({
  <span className="text-[10px] text-text-muted mt-0.5">
  Pattern: <em>Game - YYYY MM DD - Ep#</em>
  </span>
+ {hasUnfilledPlaceholders(video, video.game ? profiles[video.game] : undefined) && (
+   <div className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-sm bg-amber-500/10 border border-amber-500/30 text-amber-300 text-xs mt-1">
+     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="shrink-0 text-amber-400">
+       <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z" />
+       <line x1="12" y1="9" x2="12" y2="13" />
+       <line x1="12" y1="17" x2="12.01" y2="17" />
+     </svg>
+     <span>This title contains unfilled placeholder variables from its game profile.</span>
+   </div>
+ )}
  </div>
 
  <div className="flex flex-col gap-1.5 relative">

--- a/frontend/src/utils/__tests__/videoUtils.test.ts
+++ b/frontend/src/utils/__tests__/videoUtils.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect } from "vitest";
+import {
+  generateYouTubeTitle,
+  getVideoTitleSegments,
+  hasUnfilledPlaceholders,
+} from "../videoUtils";
+import { VideoFile, GameProfile, YTVideo } from "../../types";
+
+describe("videoUtils - Title generation & placeholder detection", () => {
+  const sampleVideo: VideoFile = {
+    name: "2026-08-26 14-30-00.mp4",
+    path: "/videos/2026-08-26 14-30-00.mp4",
+    size: 104857600,
+    modTime: 1787754600000,
+    folder: "/videos",
+    game: "Overwatch 2",
+  };
+
+  const multiplayerProfile: GameProfile = {
+    type: "multiplayer",
+    titleTemplate: "{game} - {event} - {gamemode} - {date}",
+    modes: ["Quick Play", "Competitive", "Arcade"],
+  };
+
+  describe("generateYouTubeTitle", () => {
+    it("generates standard singleplayer title with game and datePart", () => {
+      const title = generateYouTubeTitle(
+        sampleVideo.name,
+        sampleVideo.game,
+        sampleVideo.episode,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        sampleVideo.modTime
+      );
+      expect(title).toBe("Overwatch 2 — 26/08/26");
+    });
+
+    it("generates multiplayer title with fallback placeholders when unfilled", () => {
+      const title = generateYouTubeTitle(
+        sampleVideo.name,
+        sampleVideo.game,
+        sampleVideo.episode,
+        multiplayerProfile,
+        undefined,
+        undefined,
+        undefined,
+        sampleVideo.modTime
+      );
+      expect(title).toBe("Overwatch 2 - Title - Mode - 26/08/26");
+    });
+
+    it("generates multiplayer title with user-provided fields when filled", () => {
+      const title = generateYouTubeTitle(
+        sampleVideo.name,
+        sampleVideo.game,
+        sampleVideo.episode,
+        multiplayerProfile,
+        "Grand Finals",
+        "Competitive",
+        undefined,
+        sampleVideo.modTime
+      );
+      expect(title).toBe("Overwatch 2 - Grand Finals - Competitive - 26/08/26");
+    });
+
+    it("handles custom variables in titleTemplate", () => {
+      const customProfile: GameProfile = {
+        type: "multiplayer",
+        titleTemplate: "{game} | {event} | {gamemode} | {map} | {hero} | {date}",
+      };
+      const titleWithFallbacks = generateYouTubeTitle(
+        sampleVideo.name,
+        sampleVideo.game,
+        sampleVideo.episode,
+        customProfile,
+        "",
+        "",
+        {},
+        sampleVideo.modTime
+      );
+      expect(titleWithFallbacks).toBe("Overwatch 2 | Title | Mode | Map | Hero | 26/08/26");
+
+      const titleFilled = generateYouTubeTitle(
+        sampleVideo.name,
+        sampleVideo.game,
+        sampleVideo.episode,
+        customProfile,
+        "Clash",
+        "Ranked",
+        { map: "King's Row", hero: "Tracer" },
+        sampleVideo.modTime
+      );
+      expect(titleFilled).toBe("Overwatch 2 | Clash | Ranked | King's Row | Tracer | 26/08/26");
+    });
+  });
+
+  describe("getVideoTitleSegments", () => {
+    it("returns single segment for YTVideo", () => {
+      const ytVid: YTVideo = {
+        id: "yt-123",
+        title: "YouTube Video Title",
+        description: "",
+        publishedAt: "2026-01-01T00:00:00Z",
+        thumbnailUrl: "https://example.com/thumb.jpg",
+        viewCount: 10,
+        likeCount: 2,
+        duration: "PT5M",
+        privacy: "public",
+        localFile: "",
+      };
+
+      const result = getVideoTitleSegments(ytVid);
+      expect(result.fullTitle).toBe("YouTube Video Title");
+      expect(result.hasPlaceholders).toBe(false);
+      expect(result.segments).toEqual([
+        { text: "YouTube Video Title", isPlaceholder: false },
+      ]);
+    });
+
+    it("identifies unfilled placeholder variables in multiplayer profile", () => {
+      const video: VideoFile = {
+        ...sampleVideo,
+        event: "",
+        gameMode: "",
+      };
+
+      const result = getVideoTitleSegments(video, multiplayerProfile);
+      expect(result.fullTitle).toBe("Overwatch 2 - Title - Mode - 26/08/26");
+      expect(result.hasPlaceholders).toBe(true);
+
+      expect(result.segments).toEqual([
+        { text: "Overwatch 2", isGameTag: true, isPlaceholder: false },
+        { text: " - ", isPlaceholder: false },
+        { text: "Title", isPlaceholder: true, varName: "event" },
+        { text: " - ", isPlaceholder: false },
+        { text: "Mode", isPlaceholder: true, varName: "gamemode" },
+        { text: " - ", isPlaceholder: false },
+        { text: "26/08/26", isPlaceholder: false },
+      ]);
+    });
+
+    it("identifies partially filled variables in multiplayer profile", () => {
+      const video: VideoFile = {
+        ...sampleVideo,
+        event: "Scrimmage",
+        gameMode: "",
+      };
+
+      const result = getVideoTitleSegments(video, multiplayerProfile);
+      expect(result.fullTitle).toBe("Overwatch 2 - Scrimmage - Mode - 26/08/26");
+      expect(result.hasPlaceholders).toBe(true);
+
+      expect(result.segments).toEqual([
+        { text: "Overwatch 2", isGameTag: true, isPlaceholder: false },
+        { text: " - ", isPlaceholder: false },
+        { text: "Scrimmage", isPlaceholder: false },
+        { text: " - ", isPlaceholder: false },
+        { text: "Mode", isPlaceholder: true, varName: "gamemode" },
+        { text: " - ", isPlaceholder: false },
+        { text: "26/08/26", isPlaceholder: false },
+      ]);
+    });
+
+    it("returns no placeholders when all fields are filled", () => {
+      const video: VideoFile = {
+        ...sampleVideo,
+        event: "Championship",
+        gameMode: "Payload",
+      };
+
+      const result = getVideoTitleSegments(video, multiplayerProfile);
+      expect(result.fullTitle).toBe("Overwatch 2 - Championship - Payload - 26/08/26");
+      expect(result.hasPlaceholders).toBe(false);
+
+      expect(result.segments).toEqual([
+        { text: "Overwatch 2", isGameTag: true, isPlaceholder: false },
+        { text: " - ", isPlaceholder: false },
+        { text: "Championship", isPlaceholder: false },
+        { text: " - ", isPlaceholder: false },
+        { text: "Payload", isPlaceholder: false },
+        { text: " - ", isPlaceholder: false },
+        { text: "26/08/26", isPlaceholder: false },
+      ]);
+    });
+
+    it("handles custom variables and highlights unfilled ones", () => {
+      const customProfile: GameProfile = {
+        type: "multiplayer",
+        titleTemplate: "{game} | {event} | {map} | {date}",
+      };
+
+      const video: VideoFile = {
+        ...sampleVideo,
+        event: "Tournament",
+        customVars: { map: "" },
+      };
+
+      const result = getVideoTitleSegments(video, customProfile);
+      expect(result.fullTitle).toBe("Overwatch 2 | Tournament | Map | 26/08/26");
+      expect(result.hasPlaceholders).toBe(true);
+
+      expect(result.segments).toEqual([
+        { text: "Overwatch 2", isGameTag: true, isPlaceholder: false },
+        { text: " | ", isPlaceholder: false },
+        { text: "Tournament", isPlaceholder: false },
+        { text: " | ", isPlaceholder: false },
+        { text: "Map", isPlaceholder: true, varName: "map" },
+        { text: " | ", isPlaceholder: false },
+        { text: "26/08/26", isPlaceholder: false },
+      ]);
+    });
+
+    it("handles raw placeholders in manual youtubeTitle", () => {
+      const video: VideoFile = {
+        ...sampleVideo,
+        youtubeTitle: "My Epic Match {event} - {gamemode}",
+      };
+
+      const result = getVideoTitleSegments(video);
+      expect(result.fullTitle).toBe("My Epic Match {event} - {gamemode}");
+      expect(result.hasPlaceholders).toBe(true);
+
+      expect(result.segments).toEqual([
+        { text: "My Epic Match ", isPlaceholder: false },
+        { text: "{event}", isPlaceholder: true, varName: "event" },
+        { text: " - ", isPlaceholder: false },
+        { text: "{gamemode}", isPlaceholder: true, varName: "gamemode" },
+      ]);
+    });
+
+    it("handles singleplayer video without profile or with singleplayer profile", () => {
+      const video: VideoFile = {
+        ...sampleVideo,
+        episode: 3,
+      };
+
+      const result = getVideoTitleSegments(video, { type: "singleplayer", titleTemplate: "" });
+      expect(result.fullTitle).toBe("Overwatch 2 — 26/08/26 — 3");
+      expect(result.hasPlaceholders).toBe(false);
+      expect(result.segments).toEqual([
+        { text: "Overwatch 2", isGameTag: true, isPlaceholder: false },
+        { text: " — 26/08/26 — 3", isPlaceholder: false },
+      ]);
+    });
+  });
+
+  describe("hasUnfilledPlaceholders", () => {
+    it("returns true when multiplayer profile has unfilled variables", () => {
+      const video: VideoFile = { ...sampleVideo, event: "", gameMode: "" };
+      expect(hasUnfilledPlaceholders(video, multiplayerProfile)).toBe(true);
+    });
+
+    it("returns false when multiplayer profile has all variables filled", () => {
+      const video: VideoFile = { ...sampleVideo, event: "Match", gameMode: "Competitive" };
+      expect(hasUnfilledPlaceholders(video, multiplayerProfile)).toBe(false);
+    });
+
+    it("returns false for standard singleplayer video", () => {
+      expect(hasUnfilledPlaceholders(sampleVideo)).toBe(false);
+    });
+  });
+});

--- a/frontend/src/utils/videoUtils.ts
+++ b/frontend/src/utils/videoUtils.ts
@@ -21,73 +21,75 @@ export function formatDuration(seconds: number): string {
  return `${m}:${s < 10 ? "0" : ""}${s}`;
 }
 
-export function generateYouTubeTitle(
- filename: string,
- game?: string,
- episode?: number,
- profile?: GameProfile,
- event?: string,
- gameMode?: string,
- customVars?: Record<string, string>,
- modTime?: number
-): string {
- const stem = filename.replace(/\.[^/.]+$/, "");
- 
- let datePart = "";
- 
- // 1. OBS Pattern (YYYY-MM-DD)
- const obsPattern = /(?:^|_|-|\s)(\d{4})-(\d{2})-(\d{2})(?:_|-|\s|$)/;
- const obsMatch = stem.match(obsPattern);
- 
- // 2. US/EU Pattern (MM-DD-YYYY or DD-MM-YYYY)
- const usPattern = /(?:^|_|-|\s)(\d{1,2})-(\d{1,2})-(\d{4})(?:_|-|\s|$)/;
- const usMatch = stem.match(usPattern);
- 
- if (obsMatch) {
- const [, year, month, day] = obsMatch;
- datePart = `${parseInt(day)}/${month.padStart(2, '0')}/${year.slice(-2)}`;
- } else if (usMatch) {
- const [, p1, p2, year] = usMatch;
- let day = p2;
- let month = p1;
- if (parseInt(p1) > 12) {
- day = p1;
- month = p2;
- }
- datePart = `${parseInt(day)}/${month.padStart(2, '0')}/${year.slice(-2)}`;
- } else {
- const d = modTime ? new Date(modTime) : new Date();
- datePart = `${d.getDate()}/${(d.getMonth() + 1).toString().padStart(2, '0')}/${d.getFullYear().toString().slice(-2)}`;
- }
- 
- if (!game) return datePart;
+export function extractDatePart(filename: string, modTime?: number): string {
+  const stem = filename.replace(/\.[^/.]+$/, "");
 
- if (profile && profile.type === "multiplayer") {
- let template = profile.titleTemplate || "{event} - {gamemode} - {date}";
- let res = template.replace(/\{game\}/gi, game);
- res = res.replace(/\{event\}/gi, event || "Title");
- res = res.replace(/\{gamemode\}/gi, gameMode || "Mode");
- res = res.replace(/\{date\}/gi, datePart);
- res = res.replace(/\{episode\}/gi, (episode || 0).toString());
- 
- const detectedCustomVars = extractCustomVars(template);
- detectedCustomVars.forEach(k => {
- const v = customVars?.[k];
- const val = v || k.charAt(0).toUpperCase() + k.slice(1);
- res = res.replace(new RegExp(`\\{${k}\\}`, 'gi'), val);
- });
- 
- // Cleanup multiple adjacent hyphens or spaces resulting from empty variables
- res = res.replace(/(?:\s*-\s*){2,}/g, " - ");
- res = res.replace(/^\s*-\s*/, "");
- res = res.replace(/\s*-\s*$/, "");
- 
- return res;
- }
- 
- const epSuffix = (episode && episode > 0) ? ` — ${episode}` : "";
- 
- return `${game} — ${datePart}${epSuffix}`;
+  // 1. OBS Pattern (YYYY-MM-DD)
+  const obsPattern = /(?:^|_|-|\s)(\d{4})-(\d{2})-(\d{2})(?:_|-|\s|$)/;
+  const obsMatch = stem.match(obsPattern);
+
+  // 2. US/EU Pattern (MM-DD-YYYY or DD-MM-YYYY)
+  const usPattern = /(?:^|_|-|\s)(\d{1,2})-(\d{1,2})-(\d{4})(?:_|-|\s|$)/;
+  const usMatch = stem.match(usPattern);
+
+  if (obsMatch) {
+    const [, year, month, day] = obsMatch;
+    return `${parseInt(day)}/${month.padStart(2, '0')}/${year.slice(-2)}`;
+  } else if (usMatch) {
+    const [, p1, p2, year] = usMatch;
+    let day = p2;
+    let month = p1;
+    if (parseInt(p1) > 12) {
+      day = p1;
+      month = p2;
+    }
+    return `${parseInt(day)}/${month.padStart(2, '0')}/${year.slice(-2)}`;
+  } else {
+    const d = modTime ? new Date(modTime) : new Date();
+    return `${d.getDate()}/${(d.getMonth() + 1).toString().padStart(2, '0')}/${d.getFullYear().toString().slice(-2)}`;
+  }
+}
+
+export function generateYouTubeTitle(
+  filename: string,
+  game?: string,
+  episode?: number,
+  profile?: GameProfile,
+  event?: string,
+  gameMode?: string,
+  customVars?: Record<string, string>,
+  modTime?: number
+): string {
+  const datePart = extractDatePart(filename, modTime);
+
+  if (!game) return datePart;
+
+  if (profile && profile.type === "multiplayer") {
+    let template = profile.titleTemplate || "{event} - {gamemode} - {date}";
+    let res = template.replace(/\{game\}/gi, game);
+    res = res.replace(/\{event\}/gi, event || "Title");
+    res = res.replace(/\{gamemode\}/gi, gameMode || "Mode");
+    res = res.replace(/\{date\}/gi, datePart);
+    res = res.replace(/\{episode\}/gi, (episode || 0).toString());
+
+    const detectedCustomVars = extractCustomVars(template);
+    detectedCustomVars.forEach((k) => {
+      const v = customVars?.[k];
+      const val = v || k.charAt(0).toUpperCase() + k.slice(1);
+      res = res.replace(new RegExp(`\\{${k}\\}`, "gi"), val);
+    });
+
+    // Cleanup multiple adjacent hyphens or spaces resulting from empty variables
+    res = res.replace(/(?:\s*-\s*){2,}/g, " - ");
+    res = res.replace(/^\s*-\s*/, "");
+    res = res.replace(/\s*-\s*$/, "");
+
+    return res;
+  }
+
+  const epSuffix = episode && episode > 0 ? ` — ${episode}` : "";
+
+  return `${game} — ${datePart}${epSuffix}`;
 }
 
 export function toLocalDateKey(ms: number) {
@@ -192,8 +194,187 @@ export function extractCustomVars(template: string): string[] {
 }
 
 export function extractOrderedInputVars(template: string): string[] {
- if (!template) return [];
- const matches = [...template.matchAll(/\{([^}]+)\}/g)];
- const allVars = matches.map(m => m[1].toLowerCase());
- return Array.from(new Set(allVars)).filter(v => v !== 'game' && v !== 'date' && v !== 'episode');
+  if (!template) return [];
+  const matches = [...template.matchAll(/\{([^}]+)\}/g)];
+  const allVars = matches.map(m => m[1].toLowerCase());
+  return Array.from(new Set(allVars)).filter(v => v !== 'game' && v !== 'date' && v !== 'episode');
+}
+
+export interface TitleSegment {
+  text: string;
+  isPlaceholder?: boolean;
+  isGameTag?: boolean;
+  varName?: string;
+}
+
+export interface TitleSegmentsResult {
+  fullTitle: string;
+  segments: TitleSegment[];
+  hasPlaceholders: boolean;
+}
+
+export function getVideoTitleSegments(
+  video: YTVideo | VideoFile,
+  profile?: GameProfile
+): TitleSegmentsResult {
+  // If YouTube video, return plain title
+  if (!("path" in video)) {
+    const fullTitle = video.title || "";
+    return {
+      fullTitle,
+      segments: [{ text: fullTitle, isPlaceholder: false }],
+      hasPlaceholders: false,
+    };
+  }
+
+  const localVideo = video as VideoFile;
+  const isMultiplayer = profile && profile.type === "multiplayer";
+
+  if (isMultiplayer) {
+    const template = profile.titleTemplate || "{event} - {gamemode} - {date}";
+    const datePart = extractDatePart(localVideo.name, localVideo.modTime);
+    const customVars = localVideo.customVars || {};
+    const segments: TitleSegment[] = [];
+
+    const regex = /\{([^}]+)\}/g;
+    let lastIndex = 0;
+    let match: RegExpExecArray | null;
+
+    while ((match = regex.exec(template)) !== null) {
+      const matchIndex = match.index;
+      if (matchIndex > lastIndex) {
+        const literalText = template.slice(lastIndex, matchIndex);
+        segments.push({ text: literalText, isPlaceholder: false });
+      }
+
+      const varRaw = match[1];
+      const varKey = varRaw.toLowerCase();
+
+      if (varKey === "game") {
+        const gameName = localVideo.game || "";
+        segments.push({
+          text: gameName,
+          isGameTag: Boolean(gameName),
+          isPlaceholder: false,
+        });
+      } else if (varKey === "date") {
+        segments.push({ text: datePart, isPlaceholder: false });
+      } else if (varKey === "episode") {
+        const epVal = (localVideo.episode || 0).toString();
+        segments.push({ text: epVal, isPlaceholder: false });
+      } else if (varKey === "event") {
+        if (localVideo.event && localVideo.event.trim() !== "") {
+          segments.push({ text: localVideo.event.trim(), isPlaceholder: false });
+        } else {
+          segments.push({ text: "Title", isPlaceholder: true, varName: "event" });
+        }
+      } else if (varKey === "gamemode" || varKey === "game_mode") {
+        if (localVideo.gameMode && localVideo.gameMode.trim() !== "") {
+          segments.push({ text: localVideo.gameMode.trim(), isPlaceholder: false });
+        } else {
+          segments.push({ text: "Mode", isPlaceholder: true, varName: "gamemode" });
+        }
+      } else {
+        // Custom variable
+        const customVal = customVars[varKey] ?? customVars[varRaw];
+        if (customVal && customVal.trim() !== "") {
+          segments.push({ text: customVal.trim(), isPlaceholder: false });
+        } else {
+          const fallback = varKey.charAt(0).toUpperCase() + varKey.slice(1);
+          segments.push({ text: fallback, isPlaceholder: true, varName: varKey });
+        }
+      }
+
+      lastIndex = regex.lastIndex;
+    }
+
+    if (lastIndex < template.length) {
+      segments.push({ text: template.slice(lastIndex), isPlaceholder: false });
+    }
+
+    const fullTitle = segments.map((s) => s.text).join("");
+    const hasPlaceholders = segments.some((s) => s.isPlaceholder === true);
+
+    return {
+      fullTitle,
+      segments,
+      hasPlaceholders,
+    };
+  }
+
+  // Not multiplayer profile
+  if (localVideo.youtubeTitle) {
+    const rawTitle = localVideo.youtubeTitle;
+    const rawRegex = /\{([^}]+)\}/g;
+    if (rawRegex.test(rawTitle)) {
+      rawRegex.lastIndex = 0;
+      const segments: TitleSegment[] = [];
+      let lastIndex = 0;
+      let match: RegExpExecArray | null;
+
+      while ((match = rawRegex.exec(rawTitle)) !== null) {
+        if (match.index > lastIndex) {
+          segments.push({ text: rawTitle.slice(lastIndex, match.index), isPlaceholder: false });
+        }
+        segments.push({ text: match[0], isPlaceholder: true, varName: match[1].toLowerCase() });
+        lastIndex = rawRegex.lastIndex;
+      }
+      if (lastIndex < rawTitle.length) {
+        segments.push({ text: rawTitle.slice(lastIndex), isPlaceholder: false });
+      }
+      return {
+        fullTitle: rawTitle,
+        segments,
+        hasPlaceholders: true,
+      };
+    }
+
+    // Regular manual youtubeTitle
+    if (localVideo.game && rawTitle.startsWith(localVideo.game)) {
+      return {
+        fullTitle: rawTitle,
+        segments: [
+          { text: localVideo.game, isGameTag: true, isPlaceholder: false },
+          { text: rawTitle.slice(localVideo.game.length), isPlaceholder: false },
+        ],
+        hasPlaceholders: false,
+      };
+    }
+
+    return {
+      fullTitle: rawTitle,
+      segments: [{ text: rawTitle, isPlaceholder: false }],
+      hasPlaceholders: false,
+    };
+  }
+
+  // Default singleplayer title: Game — DD/MM/YY — Ep#
+  const datePart = extractDatePart(localVideo.name, localVideo.modTime);
+  const epSuffix = localVideo.episode && localVideo.episode > 0 ? ` — ${localVideo.episode}` : "";
+
+  if (localVideo.game) {
+    const fullTitle = `${localVideo.game} — ${datePart}${epSuffix}`;
+    return {
+      fullTitle,
+      segments: [
+        { text: localVideo.game, isGameTag: true, isPlaceholder: false },
+        { text: ` — ${datePart}${epSuffix}`, isPlaceholder: false },
+      ],
+      hasPlaceholders: false,
+    };
+  }
+
+  const fullTitle = `${datePart}${epSuffix}`;
+  return {
+    fullTitle,
+    segments: [{ text: fullTitle, isPlaceholder: false }],
+    hasPlaceholders: false,
+  };
+}
+
+export function hasUnfilledPlaceholders(
+  video: VideoFile | YTVideo,
+  profile?: GameProfile
+): boolean {
+  return getVideoTitleSegments(video, profile).hasPlaceholders;
 }


### PR DESCRIPTION
﻿Closes #46

### Summary of Changes
- Implemented `getVideoTitleSegments` and `hasUnfilledPlaceholders` in `videoUtils.ts` to identify literal text, game tags, and unfilled placeholder tokens (`Title`, `Mode`, custom variables, and raw `{...}` placeholders).
- Updated `VideoPill.tsx` to render unfilled placeholder tokens as subtle amber warning badges across grid and list views.
- Added placeholder warning notification in `UploadDialog.tsx` when uploading videos with unfilled game profile variables.
- Added comprehensive unit tests in `videoUtils.test.ts` and component test suite in `VideoPill.test.tsx`.
