### PR TITLE
Allow associating and updating YouTube playlists for existing tags (fixes #51)

### DIFF
--- a/backend/config.go
+++ b/backend/config.go
@@ -287,7 +287,7 @@ func (a *App) SetVideoGames(paths []string, game string, event string, gameMode 
 	return a.saveConfig()
 }
 
-// SetTagPlaylist links a game tag to a YouTube playlist ID
+// SetTagPlaylist links a game tag to a YouTube playlist ID and retroactively updates existing videos.
 func (a *App) SetTagPlaylist(tag string, playlistID string) error {
 	if tag == "" {
 		return fmt.Errorf("tag cannot be empty")
@@ -298,7 +298,86 @@ func (a *App) SetTagPlaylist(tag string, playlistID string) error {
 	}
 	a.config.TagPlaylists[tag] = playlistID
 	a.configMu.Unlock()
-	return a.saveConfig()
+	
+	err := a.saveConfig()
+	if err != nil {
+		return err
+	}
+
+	// Retroactively update existing videos
+	// Run in goroutine to not block UI
+	go func() {
+		// Find all videos with this tag
+		a.db.mu.Lock()
+		rows, dbErr := a.db.conn.Query("SELECT id FROM yt_videos WHERE game_tag = ?", tag)
+		if dbErr != nil {
+			a.db.mu.Unlock()
+			appLog("[SetTagPlaylist] DB error finding videos: %v", dbErr)
+			return
+		}
+		
+		var videoIDs []string
+		for rows.Next() {
+			var vid string
+			if err := rows.Scan(&vid); err == nil {
+				videoIDs = append(videoIDs, vid)
+			}
+		}
+		rows.Close()
+		a.db.mu.Unlock()
+
+		if len(videoIDs) > 0 {
+			appLog("[SetTagPlaylist] Retroactively adding %d videos to playlist %s", len(videoIDs), playlistID)
+			for _, vid := range videoIDs {
+				var exists int
+				a.db.mu.Lock()
+				a.db.conn.QueryRow("SELECT 1 FROM yt_playlist_items WHERE playlist_id = ? AND video_id = ?", playlistID, vid).Scan(&exists)
+				a.db.mu.Unlock()
+				
+				if exists == 0 {
+					_ = a.AddVideoToPlaylist(playlistID, vid)
+				}
+			}
+		}
+	}()
+
+	return nil
+}
+
+// GetAllGameTags returns a list of unique game tags from both configuration and database.
+func (a *App) GetAllGameTags() ([]string, error) {
+	tagSet := make(map[string]bool)
+
+	// From Config
+	a.configMu.Lock()
+	for tag := range a.config.TagPlaylists {
+		if tag != "" {
+			tagSet[tag] = true
+		}
+	}
+	a.configMu.Unlock()
+
+	// From DB
+	a.db.mu.Lock()
+	defer a.db.mu.Unlock()
+	rows, err := a.db.conn.Query("SELECT DISTINCT game_tag FROM yt_videos WHERE game_tag IS NOT NULL AND game_tag != ''")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var t string
+		if err := rows.Scan(&t); err == nil && t != "" {
+			tagSet[t] = true
+		}
+	}
+
+	var result []string
+	for t := range tagSet {
+		result = append(result, t)
+	}
+	return result, nil
 }
 
 // SaveVideoMetadata updates all metadata for a specific video and saves the config

--- a/frontend/src/components/layout/SettingsPanel.tsx
+++ b/frontend/src/components/layout/SettingsPanel.tsx
@@ -11,6 +11,9 @@ import {
   SaveGameProfile,
   DeleteGameProfile,
   SetTitleSeparator,
+  GetAllGameTags,
+  SetTagPlaylist,
+  GetChannelPlaylists,
 } from "../../../wailsjs/go/backend/App";
 // @ts-ignore
 import {
@@ -21,7 +24,7 @@ import {
   DisconnectSteam,
 } from "../../../wailsjs/go/backend/App";
 import { EventsOn, EventsOff } from "../../../wailsjs/runtime/runtime";
-import { GameProfile } from "../../types";
+import { GameProfile, YTPlaylist } from "../../types";
 
 interface YouTubeChannel {
   id: string;
@@ -65,6 +68,14 @@ export default function SettingsPanel({ open, onClose }: Props) {
   }>({ tag: "", profile: { type: "singleplayer", titleTemplate: "" } });
   const [savingProfile, setSavingProfile] = useState(false);
 
+  // Tag Playlists state
+  const [allTags, setAllTags] = useState<string[]>([]);
+  const [tagPlaylists, setTagPlaylists] = useState<Record<string, string>>({});
+  const [availablePlaylists, setAvailablePlaylists] = useState<YTPlaylist[]>([]);
+  const [tagPlaylistSaving, setTagPlaylistSaving] = useState<string | null>(null);
+  const [selectedTag, setSelectedTag] = useState<string>("");
+  const [selectedPlaylistForTag, setSelectedPlaylistForTag] = useState<string>("none");
+
   useEffect(() => {
     if (!open) return;
     IsYouTubeAuthed()
@@ -84,11 +95,21 @@ export default function SettingsPanel({ open, onClose }: Props) {
       .then((cfg) => {
         setCredsLoaded(!!cfg.youtube_client_id);
         setGameProfiles(cfg.game_profiles || {});
+        setTagPlaylists(cfg.tag_playlists || {});
         setTitleSeparator(cfg.title_separator || " - ");
         if (cfg.steam_api_key) setSteamApiKey(cfg.steam_api_key);
         if (cfg.steam_id) setSteamId(cfg.steam_id);
       })
       .catch(() => setCredsLoaded(false));
+      
+    // Load tag management data
+    GetAllGameTags()
+      .then(setAllTags)
+      .catch(() => {});
+    GetChannelPlaylists("recent")
+      .then(setAvailablePlaylists)
+      .catch(() => {});
+
     // Load auto-launch state
     GetAutoLaunch()
       .then(setAutoLaunch)
@@ -282,7 +303,8 @@ export default function SettingsPanel({ open, onClose }: Props) {
               </label>
               <input
                 type="password"
-                className="input input-sm input-bordered w-full text-xs"
+                style={{ backgroundColor: "#141416", color: "#f4f4f5" }}
+                className="w-full bg-[#141416] border border-white/10 rounded px-2.5 py-1.5 text-xs text-text-primary outline-none focus:border-accent"
                 placeholder="Enter Steam Web API Key"
                 value={steamApiKey}
                 onChange={(e) => setSteamApiKey(e.target.value)}
@@ -732,6 +754,105 @@ export default function SettingsPanel({ open, onClose }: Props) {
                     </div>
                   </div>
                 ))
+              )}
+            </div>
+          </section>
+
+          {/* Tag Playlists */}
+          <section className="border-b border-white/5 pb-4 last:border-0">
+            <h3 className="text-sm font-semibold text-text-muted mb-3 px-2">
+              Tag Playlists
+            </h3>
+            <div className="bg-elevated border border-border-subtle rounded-md p-3 flex flex-col gap-3">
+              <div className="flex flex-col gap-1.5">
+                <label className="text-xs font-medium text-text-secondary">
+                  Select Game Tag
+                </label>
+                <select
+                  style={{ backgroundColor: "#141416", color: "#f4f4f5" }}
+                  className="bg-[#141416] border border-white/10 rounded px-2.5 py-1.5 text-xs text-text-primary outline-none focus:border-accent cursor-pointer"
+                  value={selectedTag}
+                  onChange={(e) => {
+                    const tag = e.target.value;
+                    setSelectedTag(tag);
+                    if (tag) {
+                      setSelectedPlaylistForTag(tagPlaylists[tag] || "none");
+                    }
+                  }}
+                >
+                  <option value="" style={{ backgroundColor: "#141416", color: "#71717a" }}>
+                    -- Choose a tag to configure --
+                  </option>
+                  {allTags.map((tag) => (
+                    <option key={tag} value={tag} style={{ backgroundColor: "#141416", color: "#f4f4f5" }}>
+                      {tag} {tagPlaylists[tag] && tagPlaylists[tag] !== "none" ? " (Linked)" : ""}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {selectedTag && (
+                <div className="flex flex-col gap-3 pt-3 border-t border-white/5">
+                  <div className="flex flex-col gap-1.5">
+                    <label className="text-xs font-medium text-text-secondary">
+                      Associated YouTube Playlist
+                    </label>
+                    <select
+                      style={{ backgroundColor: "#141416", color: "#f4f4f5" }}
+                      className="bg-[#141416] border border-white/10 rounded px-2.5 py-1.5 text-xs text-text-primary outline-none focus:border-accent cursor-pointer"
+                      value={selectedPlaylistForTag}
+                      onChange={(e) => setSelectedPlaylistForTag(e.target.value)}
+                    >
+                      <option value="none" style={{ backgroundColor: "#141416", color: "#71717a" }}>
+                        No Playlist
+                      </option>
+                      {availablePlaylists.map((p) => (
+                        <option key={p.id} value={p.id} style={{ backgroundColor: "#141416", color: "#f4f4f5" }}>
+                          {p.title}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+
+                  <div className="flex items-center justify-between pt-1">
+                    <div className="text-[11px] text-text-muted truncate max-w-[200px]">
+                      {tagPlaylists[selectedTag] && tagPlaylists[selectedTag] !== "none" ? (
+                        <span>
+                          Current:{" "}
+                          <span className="text-accent">
+                            {availablePlaylists.find((p) => p.id === tagPlaylists[selectedTag])?.title || tagPlaylists[selectedTag]}
+                          </span>
+                        </span>
+                      ) : (
+                        <span>No playlist linked</span>
+                      )}
+                    </div>
+
+                    <button
+                      className="btn btn-primary btn-sm text-xs px-3"
+                      disabled={
+                        tagPlaylistSaving === selectedTag ||
+                        selectedPlaylistForTag === (tagPlaylists[selectedTag] || "none")
+                      }
+                      onClick={async () => {
+                        setTagPlaylistSaving(selectedTag);
+                        try {
+                          await SetTagPlaylist(selectedTag, selectedPlaylistForTag);
+                          setTagPlaylists((prev) => ({
+                            ...prev,
+                            [selectedTag]: selectedPlaylistForTag,
+                          }));
+                        } catch (err) {
+                          console.error("Error setting tag playlist", err);
+                        } finally {
+                          setTagPlaylistSaving(null);
+                        }
+                      }}
+                    >
+                      {tagPlaylistSaving === selectedTag ? "Saving..." : "Save"}
+                    </button>
+                  </div>
+                </div>
               )}
             </div>
           </section>

--- a/frontend/src/components/layout/__tests__/SettingsPanel.test.tsx
+++ b/frontend/src/components/layout/__tests__/SettingsPanel.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import SettingsPanel from "../SettingsPanel";
+import { describe, it, expect, vi } from "vitest";
+
+// Mock Wails backend functions
+vi.mock("../../../../wailsjs/go/backend/App", () => ({
+  IsYouTubeAuthed: vi.fn().mockResolvedValue(true),
+  GetYouTubeChannelInfo: vi.fn().mockResolvedValue({ id: "123", title: "Test", thumbnail: "" }),
+  LoadConfig: vi.fn().mockResolvedValue({ tag_playlists: { "GameA": "PL_TEST" } }),
+  GetAutoLaunch: vi.fn().mockResolvedValue(false),
+  GetWatchFolderEnabled: vi.fn().mockResolvedValue(false),
+  GetAllGameTags: vi.fn().mockResolvedValue(["GameA", "GameB"]),
+  GetChannelPlaylists: vi.fn().mockResolvedValue([{ id: "PL_1", title: "Playlist 1" }]),
+  SetTagPlaylist: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../../../../wailsjs/runtime/runtime", () => ({
+  EventsOn: vi.fn().mockReturnValue(vi.fn()),
+  EventsOff: vi.fn(),
+}));
+
+describe("SettingsPanel", () => {
+  it("renders the Tag Playlists section", async () => {
+    render(<SettingsPanel open={true} onClose={() => {}} />);
+    
+    expect(await screen.findByText("Tag Playlists")).toBeInTheDocument();
+    expect(await screen.findByText("-- Choose a tag to configure --")).toBeInTheDocument();
+  });
+});

--- a/frontend/wailsjs/go/backend/App.d.ts
+++ b/frontend/wailsjs/go/backend/App.d.ts
@@ -25,6 +25,8 @@ export function DisconnectSteam():Promise<void>;
 
 export function GetAPILogs(arg1:number):Promise<Array<backend.APILog>>;
 
+export function GetAllGameTags():Promise<Array<string>>;
+
 export function GetAutoLaunch():Promise<boolean>;
 
 export function GetCacheDir():Promise<string>;
@@ -156,6 +158,8 @@ export function UnlinkLocalVideo(arg1:string):Promise<void>;
 export function UpdatePlaylistVisibility(arg1:string,arg2:string):Promise<void>;
 
 export function UpdatePlaylistsVisibility(arg1:Array<string>,arg2:string):Promise<number>;
+
+export function UpdateVideoMonetizationStatus(arg1:string,arg2:string,arg3:string,arg4:Array<string>):Promise<void>;
 
 export function UpdateYouTubeVideoMetadata(arg1:string,arg2:string,arg3:string,arg4:string):Promise<void>;
 

--- a/frontend/wailsjs/go/backend/App.js
+++ b/frontend/wailsjs/go/backend/App.js
@@ -42,6 +42,10 @@ export function GetAPILogs(arg1) {
   return window['go']['backend']['App']['GetAPILogs'](arg1);
 }
 
+export function GetAllGameTags() {
+  return window['go']['backend']['App']['GetAllGameTags']();
+}
+
 export function GetAutoLaunch() {
   return window['go']['backend']['App']['GetAutoLaunch']();
 }
@@ -304,6 +308,10 @@ export function UpdatePlaylistVisibility(arg1, arg2) {
 
 export function UpdatePlaylistsVisibility(arg1, arg2) {
   return window['go']['backend']['App']['UpdatePlaylistsVisibility'](arg1, arg2);
+}
+
+export function UpdateVideoMonetizationStatus(arg1, arg2, arg3, arg4) {
+  return window['go']['backend']['App']['UpdateVideoMonetizationStatus'](arg1, arg2, arg3, arg4);
 }
 
 export function UpdateYouTubeVideoMetadata(arg1, arg2, arg3, arg4) {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -455,6 +455,10 @@ export namespace backend {
 	    privacy: string;
 	    localFile?: string;
 	    playlistTitle?: string;
+	    episode?: number;
+	    monetizationStatus?: string;
+	    rejectionReason?: string;
+	    statusIssues?: string[];
 	
 	    static createFrom(source: any = {}) {
 	        return new YTVideo(source);
@@ -473,6 +477,10 @@ export namespace backend {
 	        this.privacy = source["privacy"];
 	        this.localFile = source["localFile"];
 	        this.playlistTitle = source["playlistTitle"];
+	        this.episode = source["episode"];
+	        this.monetizationStatus = source["monetizationStatus"];
+	        this.rejectionReason = source["rejectionReason"];
+	        this.statusIssues = source["statusIssues"];
 	    }
 	}
 	export class YouTubeChannel {

--- a/tests/backend/tag_playlist_test.go
+++ b/tests/backend/tag_playlist_test.go
@@ -1,0 +1,64 @@
+package backend_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestTagPlaylistRetroactiveUpdate(t *testing.T) {
+	app, tempDir := setupTestApp(t)
+	defer os.RemoveAll(tempDir)
+
+	dbPath := filepath.Join(tempDir, "test.db")
+	err := app.InitTestDB(dbPath)
+	if err != nil {
+		t.Fatalf("Failed to init test DB: %v", err)
+	}
+
+	db := app.GetDB()
+
+	// Insert test videos with tags
+	_, err = db.Exec(`
+		INSERT INTO yt_videos (id, title, game_tag, synced_at)
+		VALUES 
+			('V1', 'Video 1', 'GameA', 1000),
+			('V2', 'Video 2', 'GameB', 1000),
+			('V3', 'Video 3', 'GameA', 1000)
+	`)
+	if err != nil {
+		t.Fatalf("Failed to insert test videos: %v", err)
+	}
+
+	// 1. Test GetAllGameTags
+	tags, err := app.GetAllGameTags()
+	if err != nil {
+		t.Fatalf("GetAllGameTags error: %v", err)
+	}
+
+	foundGameA := false
+	foundGameB := false
+	for _, tag := range tags {
+		if tag == "GameA" {
+			foundGameA = true
+		}
+		if tag == "GameB" {
+			foundGameB = true
+		}
+	}
+	if !foundGameA || !foundGameB {
+		t.Errorf("Expected GameA and GameB in tags, got: %v", tags)
+	}
+
+	// 2. Test SetTagPlaylist (retroactive update)
+	err = app.SetTagPlaylist("GameA", "PL_TEST_A")
+	if err != nil {
+		t.Logf("SetTagPlaylist returned error (expected if no auth): %v", err)
+	}
+
+	// Verify config was updated
+	cfg := app.LoadConfig()
+	if cfg.TagPlaylists["GameA"] != "PL_TEST_A" {
+		t.Errorf("Expected config TagPlaylists['GameA'] to be PL_TEST_A, got %v", cfg.TagPlaylists["GameA"])
+	}
+}


### PR DESCRIPTION
﻿Closes #51

### Summary of Changes
- Added a compact **Tag Playlists** management section in `SettingsPanel` to view, associate, or update YouTube playlists for game tags.
- Implemented backend retroactive sync in `SetTagPlaylist` to asynchronously add existing videos matching the tag to the selected YouTube playlist.
- Added `GetAllGameTags` helper to retrieve unique tags from both local configuration and SQLite database records.
- Enhanced styling on select and input elements across `SettingsPanel` (including Steam Web API Key) with consistent dark theme styling.
- Added backend and frontend unit tests covering tag playlist operations.

### Related Issues
- Closes #51
